### PR TITLE
feat: add --fail-open so vision API failures degrade instead of 502

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 *.pyc
 .bak-*
 .env
+/.venv*/
 # 本机 agent 指令文件，只存在于本地，不上推 GitHub
 AGENTS.md
 CLAUDE.md

--- a/AGENT_INSTALL.md
+++ b/AGENT_INSTALL.md
@@ -79,6 +79,8 @@ py -3 "<INSTALL_DIR>\codex-vision-proxy.py" --port 19100 --upstream "原始 Deep
 
 尖括号是占位符，执行前必须替换成真实绝对路径。确认代理监听 `127.0.0.1:19100`。如果端口已被占用，先确认占用者是否为用户已有的相关代理，不得直接终止未知进程。
 
+> **可选：视觉失败降级（`--fail-open`）**。默认情况下，视觉 API 调用失败（key 失效、网络不通、上游限流等）时，代理会对整个请求返回 502，纯文本会话也被阻塞。在命令末尾追加 `--fail-open` 后，代理会把失败的图片替换为 `[vision unavailable: <原因>]` 占位文本并继续转发请求，纯文本不受影响；不传该参数时保持原行为。
+
 ## 4. 修改 Codex 配置
 
 ### config.toml
@@ -131,10 +133,10 @@ launchctl kickstart -k "gui/$(id -u)/com.codex.vision-proxy"
 
 ```cmd
 @echo off
-start "Codex Vision Proxy" /min py -3 "%LOCALAPPDATA%\codex-vision-proxy\codex-vision-proxy.py" --port 19100 --upstream "原始 DeepSeek base_url" --env-file "%LOCALAPPDATA%\codex-vision-proxy\env" --log "%LOCALAPPDATA%\codex-vision-proxy\proxy.log"
+start "Codex Vision Proxy" /min py -3 "%LOCALAPPDATA%\codex-vision-proxy\codex-vision-proxy.py" --port 19100 --upstream "原始 DeepSeek base_url" --env-file "%LOCALAPPDATA%\codex-vision-proxy\env" --log "%LOCALAPPDATA%\codex-vision-proxy\proxy.log" --fail-open
 ```
 
-Startup 目录由 PowerShell 的 `[Environment]::GetFolderPath("Startup")` 获取。创建后运行一次该 `.cmd`，确认代理启动。不要把 key 写进 `.cmd`。
+`--fail-open` 为可选：视觉 API 不可用时用占位文本替代图片，避免整个请求（含纯文本）返回 502。Startup 目录由 PowerShell 的 `[Environment]::GetFolderPath("Startup")` 获取。创建后运行一次该 `.cmd`，确认代理启动。不要把 key 写进 `.cmd`。
 
 ### 其他系统
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ So don't modify Codex's existing auth config, and don't store the upstream API k
 | `extensions/opencode/vision.ts` | Single-file native plugin for OpenCode |
 | `AGENT_INSTALL.md` | Installation and verification steps for Codex agents |
 | `tests/test_image_rewrite_shapes.py` | Tests for image structures, concurrency, caching, and failure behavior |
+| `tests/test_fail_open.py` | Tests for vision-failure degradation (`--fail-open`) |
 | `tests/test_anthropic_rewrite.py` | Tests for the Anthropic Messages (Claude Code) rewrite path |
 | `tests/test_extensions.mjs` | Tests for the Pi / Oh My Pi / OpenCode extensions (node or bun) |
 | `tests/smoke_test_proxy.py` | Tests for proxy pass-through, auth, and streaming protocol |
@@ -232,6 +233,7 @@ So don't modify Codex's existing auth config, and don't store the upstream API k
 - This is an image-to-text proxy; it doesn't hand vision tokens directly to the text model.
 - Description quality depends on the configured vision model.
 - The cache lives only inside the proxy process and is cleared on restart.
+- By default, a failed vision call fails the whole request with 502 (plain text included). With `--fail-open` the proxy replaces failed images with a `[vision unavailable: <reason>]` note and keeps the text-only conversation going.
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -221,6 +221,7 @@ Codex（携带原有 Authorization）
 | `extensions/opencode/vision.ts` | OpenCode 的单文件原生 plugin |
 | `AGENT_INSTALL.md` | Codex Agent 的安装与验证步骤 |
 | `tests/test_image_rewrite_shapes.py` | 图片结构、并发、缓存及失败行为测试 |
+| `tests/test_fail_open.py` | 视觉失败降级（`--fail-open`）测试 |
 | `tests/test_anthropic_rewrite.py` | Anthropic Messages（Claude Code）改写路径测试 |
 | `tests/test_extensions.mjs` | Pi / Oh My Pi / OpenCode extension 测试（node 或 bun） |
 | `tests/smoke_test_proxy.py` | 代理透传、鉴权和流式协议测试 |
@@ -232,6 +233,7 @@ Codex（携带原有 Authorization）
 - 这是图片转文字代理，不会把视觉 token 直接交给纯文本模型。
 - 图片描述质量取决于所配置的视觉模型。
 - 缓存只存在于代理进程内，重启后清空。
+- 默认情况下，视觉调用失败会让整个请求返回 502（含纯文本）。加 `--fail-open` 后，代理会把失败的图片替换为 `[vision unavailable: <原因>]` 占位文本，纯文本会话继续可用。
 
 
 ---

--- a/codex-vision-proxy.py
+++ b/codex-vision-proxy.py
@@ -28,6 +28,22 @@ _DESC_CACHE = {}
 
 FOCUS_HINT_MAX_CHARS = 500
 
+
+class _VisionUnavailable:
+    """Marker for a vision call that failed while the proxy is in fail-open mode.
+
+    The note text is written into the conversation instead of the image, so the
+    rest of the request (plain text included) can continue on its way instead of
+    the whole conversation being answered with 502.
+    """
+
+    def __init__(self, reason):
+        self.reason = reason
+
+    def __str__(self):
+        return f"[vision unavailable: {self.reason}]"
+
+
 _ROLE_PROMPT = (
     "You are the eyes of a text-only coding assistant that cannot see images. "
     "Transcribe and describe this image so the assistant can act on it. "
@@ -308,7 +324,7 @@ _FORMATS = {
 }
 
 
-async def _describe_jobs(jobs):
+async def _describe_jobs(jobs, fail_open=False):
     requests = list(dict.fromkeys((job[2], job[3]) for job in jobs))
     semaphore = asyncio.Semaphore(4)
 
@@ -325,7 +341,11 @@ async def _describe_jobs(jobs):
     errors = []
     for key, value in results:
         if value is None or isinstance(value, VisionError):
-            errors.append(str(value) if isinstance(value, VisionError) else "image description failed")
+            reason = str(value) if isinstance(value, VisionError) else "image description failed"
+            if fail_open:
+                descriptions[key] = _VisionUnavailable(reason)
+            else:
+                errors.append(reason)
         else:
             descriptions[key] = value
     if errors:
@@ -336,7 +356,7 @@ async def _describe_jobs(jobs):
     return descriptions
 
 
-async def _rewrite_image_inputs(parsed):
+async def _rewrite_image_inputs(parsed, fail_open=False):
     fmt = _detect_format(parsed)
     if fmt is None:
         return False
@@ -344,17 +364,24 @@ async def _rewrite_image_inputs(parsed):
     jobs = collect(parsed)
     if not jobs:
         return False
-    descriptions = await _describe_jobs(jobs)
+    descriptions = await _describe_jobs(jobs, fail_open)
     prefix = "[vision model description] "
     for values, index, url, prompt in jobs:
-        values[index] = text_block(prefix + descriptions[(url, prompt)])
+        description = descriptions[(url, prompt)]
+        if isinstance(description, _VisionUnavailable):
+            values[index] = text_block(str(description))
+        else:
+            values[index] = text_block(prefix + description)
     # Explain the channel once, at the conversation's first image whichever path
     # it arrived on. The history is append-only, so "first" keeps pointing at the
     # same block on every later turn: the note is replayed, never repeated, and
     # the vision prompt is untouched so no cache key moves.
     first_values, first_index = jobs[0][:2]
     first_values.insert(first_index, text_block(channel_note))
-    _log(f"[vision-proxy] image rewrite ok format={fmt} images={len(descriptions)} cache_entries={len(_DESC_CACHE)}")
+    unavailable = sum(1 for value in descriptions.values() if isinstance(value, _VisionUnavailable))
+    state = "fail-open" if fail_open else "ok"
+    _log(f"[vision-proxy] image rewrite {state} format={fmt} images={len(descriptions)} "
+         f"unavailable={unavailable} cache_entries={len(_DESC_CACHE)}")
     return True
 
 
@@ -403,11 +430,13 @@ def _inject_reasoning_summaries(text):
 
 
 class Proxy:
-    def __init__(self, port, upstream, log_path, codex_header_compat=False, inject_reasoning_summary=False):
+    def __init__(self, port, upstream, log_path, codex_header_compat=False,
+                 inject_reasoning_summary=False, fail_open=False):
         self.port = port
         self.upstream = upstream.rstrip("/")
         self.codex_header_compat = codex_header_compat
         self.inject_reasoning_summary = inject_reasoning_summary
+        self.fail_open = fail_open
         os.environ["CODEX_VISION_PROXY_LOG"] = log_path
 
     def _upstream_headers(self, incoming):
@@ -454,7 +483,7 @@ class Proxy:
                 except json.JSONDecodeError:
                     pass
             if isinstance(parsed, dict):
-                image_changed = await _rewrite_image_inputs(parsed)
+                image_changed = await _rewrite_image_inputs(parsed, self.fail_open)
                 model_changed = _rewrite_model_compat(parsed)
                 if image_changed or model_changed:
                     body = bytearray(json.dumps(parsed).encode())
@@ -565,6 +594,8 @@ async def main():
     parser.add_argument("--env-file")
     parser.add_argument("--codex-header-compat", action="store_true")
     parser.add_argument("--inject-reasoning-summary", action="store_true")
+    parser.add_argument("--fail-open", action="store_true",
+                        help="on vision API failure replace images with a note instead of failing the request")
     parser.add_argument("--skip-vision-config-check", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
     load_env_file(args.env_file)
@@ -573,7 +604,8 @@ async def main():
             validate_vision_config()
         except VisionError as exc:
             parser.error(str(exc))
-    proxy = Proxy(args.port, args.upstream, args.log, args.codex_header_compat, args.inject_reasoning_summary)
+    proxy = Proxy(args.port, args.upstream, args.log, args.codex_header_compat,
+                  args.inject_reasoning_summary, args.fail_open)
     stopped = asyncio.Event()
     loop = asyncio.get_running_loop()
     for sig in (signal.SIGTERM, signal.SIGINT):

--- a/tests/test_fail_open.py
+++ b/tests/test_fail_open.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Unit test: --fail-open degrades vision failures instead of failing the request.
+
+Without the flag, any failed vision call raises VisionError and the proxy answers
+the whole request -- including its plain-text parts -- with 502, blocking the
+conversation. With --fail-open, failed images are replaced by a
+"[vision unavailable: <reason>]" note so the text parts of the conversation can
+continue while the vision side is broken.
+"""
+
+import asyncio
+import importlib.util
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+PNG = {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"}}
+
+
+def _load_proxy():
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        os.pardir, "codex-vision-proxy.py")
+    spec = importlib.util.spec_from_file_location("ds_proxy_fail_open_mod", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _responses_body(image_url):
+    return {"model": "user-configured-model", "input": [
+        {"type": "message", "role": "user",
+         "content": [{"type": "input_text", "text": "check this"},
+                     {"type": "input_image", "image_url": image_url}]},
+    ]}
+
+
+def test_default_remains_fail_closed():
+    mod = _load_proxy()
+
+    def boom(_url, _prompt=None):
+        raise mod.VisionError("Vision API HTTP 401: unauthorized")
+
+    mod._image_desc_from_url = boom
+    body = _responses_body("data:image/png;base64,AAA")
+    try:
+        asyncio.run(mod._rewrite_image_inputs(body))
+    except mod.VisionError as exc:
+        assert "unauthorized" in str(exc), exc
+        assert "not forwarded" in str(exc), exc
+    else:
+        raise AssertionError("without fail-open a failed vision call must raise")
+    assert body["input"][0]["content"][1]["type"] == "input_image", \
+        "the original image must not be rewritten when the call failed"
+    print("PASS: default behavior stays fail-closed")
+
+
+def test_fail_open_replaces_failed_image_with_note():
+    mod = _load_proxy()
+
+    def boom(_url, _prompt=None):
+        raise mod.VisionError("Vision API HTTP 401: unauthorized")
+
+    mod._image_desc_from_url = boom
+    body = _responses_body("data:image/png;base64,AAA")
+    assert asyncio.run(mod._rewrite_image_inputs(body, fail_open=True))
+
+    content = body["input"][0]["content"]
+    assert any(block.get("text", "").startswith("[vision proxy]") for block in content), content
+    assert content[-1]["type"] == "input_text", content
+    text = content[-1]["text"]
+    assert text.startswith("[vision unavailable: "), text
+    assert "unauthorized" in text, text
+    assert text.endswith("]"), text
+    assert "[vision model description]" not in text, \
+        "an unavailable note is not a model description and must not wear its prefix"
+    print("PASS: fail-open replaces the failed image with a note")
+
+
+def test_fail_open_mixed_success_and_failure():
+    mod = _load_proxy()
+
+    def flaky(url, _prompt=None):
+        if "GOOD" in url:
+            return "GOOD-DESC"
+        raise mod.VisionError("vision timeout")
+
+    mod._image_desc_from_url = flaky
+    body = {"model": "user-configured-model", "input": [
+        {"type": "message", "role": "user",
+         "content": [{"type": "input_text", "text": "compare"},
+                     {"type": "input_image", "image_url": "data:image/png;base64,GOOD"},
+                     {"type": "input_image", "image_url": "data:image/png;base64,BAD"}]},
+    ]}
+    assert asyncio.run(mod._rewrite_image_inputs(body, fail_open=True))
+
+    texts = [c["text"] for c in body["input"][0]["content"]]
+    assert "[vision model description] GOOD-DESC" in texts, texts
+    assert any(t.startswith("[vision unavailable: ") and "timeout" in t for t in texts), texts
+    print("PASS: in fail-open mode successes are described and failures degrade independently")
+
+
+def test_fail_open_anthropic_dialect():
+    mod = _load_proxy()
+
+    def boom(_url, _prompt=None):
+        raise mod.VisionError("Vision API network error: connection refused")
+
+    mod._image_desc_from_url = boom
+    body = {"messages": [{"role": "user", "content": [dict(PNG)]}]}
+    assert asyncio.run(mod._rewrite_image_inputs(body, fail_open=True))
+
+    content = body["messages"][0]["content"]
+    assert content[0]["text"].startswith("[vision proxy]"), content
+    assert content[-1]["type"] == "text", content
+    text = content[-1]["text"]
+    assert text.startswith("[vision unavailable: "), text
+    assert "connection refused" in text, text
+    print("PASS: fail-open degrades Anthropic-dialect failures too")
+
+
+def test_fail_open_reaches_proxy():
+    mod = _load_proxy()
+    proxy = mod.Proxy(19100, "http://127.0.0.1:9", "", fail_open=True)
+    assert proxy.fail_open is True
+    default = mod.Proxy(19100, "http://127.0.0.1:9", "")
+    assert default.fail_open is False
+    print("PASS: the --fail-open flag is wired into the Proxy")
+
+
+if __name__ == "__main__":
+    test_default_remains_fail_closed()
+    test_fail_open_replaces_failed_image_with_note()
+    test_fail_open_mixed_success_and_failure()
+    test_fail_open_anthropic_dialect()
+    test_fail_open_reaches_proxy()


### PR DESCRIPTION
## Problem

A failed vision call — invalid key, network outage, upstream 5xx/429 — raises `VisionError` inside the image-rewrite path, and the proxy answers the **whole** request with 502. Since Codex carries images inside the request body, one broken vision call blocks the entire conversation, including pure-text turns that never needed the vision model.

## Fix

Add an opt-in `--fail-open` flag. When set, failed image descriptions are replaced in-place with a `[vision unavailable: <reason>]` note instead of raising, so:

- the request continues to the upstream text model with the placeholder;
- pure-text parts of the conversation are unaffected;
- without the flag, behavior is unchanged (fail closed with 502).

The rewrite pipeline is dialect-agnostic, so the degradation covers both supported dialects (OpenAI Responses / Codex and Anthropic Messages / Claude Code).

## Tests

- New `tests/test_fail_open.py`: default stays fail-closed; fail-open replaces failures with a note (both dialects); mixed success/failure degrades only the failed images; the flag reaches the `Proxy`.
- End-to-end check with a fake vision API returning 401: default mode → image request answered 502; fail-open mode → 200 and the upstream sees the placeholder; text-only requests 200 in both modes.
- Full suite: 40 passed. The 7 `test_dominant_colors.py` errors are pre-existing on `main` (missing `mod`/`temp_dir` fixtures) and unrelated to this change.

## Docs

README (EN/CN) and `AGENT_INSTALL.md` document the flag and its failure semantics.