### PR TITLE
fix: vision failures degrade to a visible note instead of 502

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 *.pyc
 .bak-*
 .env
+/.venv*/
 # 本机 agent 指令文件，只存在于本地，不上推 GitHub
 AGENTS.md
 CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ __pycache__/
 *.pyc
 .bak-*
 .env
-/.venv*/
 # 本机 agent 指令文件，只存在于本地，不上推 GitHub
 AGENTS.md
 CLAUDE.md

--- a/codex-vision-proxy.py
+++ b/codex-vision-proxy.py
@@ -28,6 +28,22 @@ _DESC_CACHE = {}
 
 FOCUS_HINT_MAX_CHARS = 500
 
+
+class _VisionUnavailable:
+    """Marker for a vision call that failed while the proxy is in fail-open mode.
+
+    The note text is written into the conversation instead of the image, so the
+    rest of the request (plain text included) can continue on its way instead of
+    the whole conversation being answered with 502.
+    """
+
+    def __init__(self, reason):
+        self.reason = reason
+
+    def __str__(self):
+        return f"[vision unavailable: {self.reason}]"
+
+
 _ROLE_PROMPT = (
     "You are the eyes of a text-only coding assistant that cannot see images. "
     "Transcribe and describe this image so the assistant can act on it. "
@@ -308,7 +324,7 @@ _FORMATS = {
 }
 
 
-async def _describe_jobs(jobs):
+async def _describe_jobs(jobs, fail_open=False):
     requests = list(dict.fromkeys((job[2], job[3]) for job in jobs))
     semaphore = asyncio.Semaphore(4)
 
@@ -325,7 +341,11 @@ async def _describe_jobs(jobs):
     errors = []
     for key, value in results:
         if value is None or isinstance(value, VisionError):
-            errors.append(str(value) if isinstance(value, VisionError) else "image description failed")
+            reason = str(value) if isinstance(value, VisionError) else "image description failed"
+            if fail_open:
+                descriptions[key] = _VisionUnavailable(reason)
+            else:
+                errors.append(reason)
         else:
             descriptions[key] = value
     if errors:
@@ -336,7 +356,7 @@ async def _describe_jobs(jobs):
     return descriptions
 
 
-async def _rewrite_image_inputs(parsed):
+async def _rewrite_image_inputs(parsed, fail_open=False):
     fmt = _detect_format(parsed)
     if fmt is None:
         return False
@@ -344,17 +364,24 @@ async def _rewrite_image_inputs(parsed):
     jobs = collect(parsed)
     if not jobs:
         return False
-    descriptions = await _describe_jobs(jobs)
+    descriptions = await _describe_jobs(jobs, fail_open)
     prefix = "[vision model description] "
     for values, index, url, prompt in jobs:
-        values[index] = text_block(prefix + descriptions[(url, prompt)])
+        description = descriptions[(url, prompt)]
+        if isinstance(description, _VisionUnavailable):
+            values[index] = text_block(str(description))
+        else:
+            values[index] = text_block(prefix + description)
     # Explain the channel once, at the conversation's first image whichever path
     # it arrived on. The history is append-only, so "first" keeps pointing at the
     # same block on every later turn: the note is replayed, never repeated, and
     # the vision prompt is untouched so no cache key moves.
     first_values, first_index = jobs[0][:2]
     first_values.insert(first_index, text_block(channel_note))
-    _log(f"[vision-proxy] image rewrite ok format={fmt} images={len(descriptions)} cache_entries={len(_DESC_CACHE)}")
+    unavailable = sum(1 for value in descriptions.values() if isinstance(value, _VisionUnavailable))
+    state = "fail-open" if fail_open else "ok"
+    _log(f"[vision-proxy] image rewrite {state} format={fmt} images={len(descriptions)} "
+         f"unavailable={unavailable} cache_entries={len(_DESC_CACHE)}")
     return True
 
 
@@ -403,11 +430,13 @@ def _inject_reasoning_summaries(text):
 
 
 class Proxy:
-    def __init__(self, port, upstream, log_path, codex_header_compat=False, inject_reasoning_summary=False):
+    def __init__(self, port, upstream, log_path, codex_header_compat=False,
+                 inject_reasoning_summary=False, fail_open=False):
         self.port = port
         self.upstream = upstream.rstrip("/")
         self.codex_header_compat = codex_header_compat
         self.inject_reasoning_summary = inject_reasoning_summary
+        self.fail_open = fail_open
         os.environ["CODEX_VISION_PROXY_LOG"] = log_path
 
     def _upstream_headers(self, incoming):
@@ -454,7 +483,7 @@ class Proxy:
                 except json.JSONDecodeError:
                     pass
             if isinstance(parsed, dict):
-                image_changed = await _rewrite_image_inputs(parsed)
+                image_changed = await _rewrite_image_inputs(parsed, self.fail_open)
                 model_changed = _rewrite_model_compat(parsed)
                 if image_changed or model_changed:
                     body = bytearray(json.dumps(parsed).encode())
@@ -565,6 +594,8 @@ async def main():
     parser.add_argument("--env-file")
     parser.add_argument("--codex-header-compat", action="store_true")
     parser.add_argument("--inject-reasoning-summary", action="store_true")
+    parser.add_argument("--fail-open", action="store_true",
+                        help="on vision API failure replace images with a note instead of failing the request")
     parser.add_argument("--skip-vision-config-check", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
     load_env_file(args.env_file)
@@ -573,7 +604,8 @@ async def main():
             validate_vision_config()
         except VisionError as exc:
             parser.error(str(exc))
-    proxy = Proxy(args.port, args.upstream, args.log, args.codex_header_compat, args.inject_reasoning_summary)
+    proxy = Proxy(args.port, args.upstream, args.log, args.codex_header_compat,
+                  args.inject_reasoning_summary, args.fail_open)
     stopped = asyncio.Event()
     loop = asyncio.get_running_loop()
     for sig in (signal.SIGTERM, signal.SIGINT):

--- a/codex-vision-proxy.py
+++ b/codex-vision-proxy.py
@@ -30,18 +30,21 @@ FOCUS_HINT_MAX_CHARS = 500
 
 
 class _VisionUnavailable:
-    """Marker for a vision call that failed while the proxy is in fail-open mode.
+    """Marker for a vision call that failed.
 
     The note text is written into the conversation instead of the image, so the
     rest of the request (plain text included) can continue on its way instead of
-    the whole conversation being answered with 502.
+    the whole conversation being answered with 502. The failure is never silent:
+    the reason travels with the note, the failure is logged, and the note asks
+    the model to tell the user that the vision tool is unavailable.
     """
 
     def __init__(self, reason):
         self.reason = reason
 
     def __str__(self):
-        return f"[vision unavailable: {self.reason}]"
+        return (f"[vision unavailable: {self.reason}] "
+                "The vision tool is temporarily unavailable; let the user know.")
 
 
 _ROLE_PROMPT = (
@@ -324,7 +327,7 @@ _FORMATS = {
 }
 
 
-async def _describe_jobs(jobs, fail_open=False):
+async def _describe_jobs(jobs):
     requests = list(dict.fromkeys((job[2], job[3]) for job in jobs))
     semaphore = asyncio.Semaphore(4)
 
@@ -338,25 +341,16 @@ async def _describe_jobs(jobs, fail_open=False):
 
     results = await asyncio.gather(*(run(url, prompt) for url, prompt in requests))
     descriptions = {}
-    errors = []
     for key, value in results:
         if value is None or isinstance(value, VisionError):
             reason = str(value) if isinstance(value, VisionError) else "image description failed"
-            if fail_open:
-                descriptions[key] = _VisionUnavailable(reason)
-            else:
-                errors.append(reason)
+            descriptions[key] = _VisionUnavailable(reason)
         else:
             descriptions[key] = value
-    if errors:
-        details = "；".join(dict.fromkeys(errors))
-        raise VisionError(
-            f"{len(errors)} image(s) failed to describe; original images were not forwarded to the text-only model: {details}"
-        )
     return descriptions
 
 
-async def _rewrite_image_inputs(parsed, fail_open=False):
+async def _rewrite_image_inputs(parsed):
     fmt = _detect_format(parsed)
     if fmt is None:
         return False
@@ -364,7 +358,7 @@ async def _rewrite_image_inputs(parsed, fail_open=False):
     jobs = collect(parsed)
     if not jobs:
         return False
-    descriptions = await _describe_jobs(jobs, fail_open)
+    descriptions = await _describe_jobs(jobs)
     prefix = "[vision model description] "
     for values, index, url, prompt in jobs:
         description = descriptions[(url, prompt)]
@@ -379,7 +373,7 @@ async def _rewrite_image_inputs(parsed, fail_open=False):
     first_values, first_index = jobs[0][:2]
     first_values.insert(first_index, text_block(channel_note))
     unavailable = sum(1 for value in descriptions.values() if isinstance(value, _VisionUnavailable))
-    state = "fail-open" if fail_open else "ok"
+    state = "degraded" if unavailable else "ok"
     _log(f"[vision-proxy] image rewrite {state} format={fmt} images={len(descriptions)} "
          f"unavailable={unavailable} cache_entries={len(_DESC_CACHE)}")
     return True
@@ -431,12 +425,11 @@ def _inject_reasoning_summaries(text):
 
 class Proxy:
     def __init__(self, port, upstream, log_path, codex_header_compat=False,
-                 inject_reasoning_summary=False, fail_open=False):
+                 inject_reasoning_summary=False):
         self.port = port
         self.upstream = upstream.rstrip("/")
         self.codex_header_compat = codex_header_compat
         self.inject_reasoning_summary = inject_reasoning_summary
-        self.fail_open = fail_open
         os.environ["CODEX_VISION_PROXY_LOG"] = log_path
 
     def _upstream_headers(self, incoming):
@@ -483,7 +476,7 @@ class Proxy:
                 except json.JSONDecodeError:
                     pass
             if isinstance(parsed, dict):
-                image_changed = await _rewrite_image_inputs(parsed, self.fail_open)
+                image_changed = await _rewrite_image_inputs(parsed)
                 model_changed = _rewrite_model_compat(parsed)
                 if image_changed or model_changed:
                     body = bytearray(json.dumps(parsed).encode())
@@ -594,8 +587,6 @@ async def main():
     parser.add_argument("--env-file")
     parser.add_argument("--codex-header-compat", action="store_true")
     parser.add_argument("--inject-reasoning-summary", action="store_true")
-    parser.add_argument("--fail-open", action="store_true",
-                        help="on vision API failure replace images with a note instead of failing the request")
     parser.add_argument("--skip-vision-config-check", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
     load_env_file(args.env_file)
@@ -605,7 +596,7 @@ async def main():
         except VisionError as exc:
             parser.error(str(exc))
     proxy = Proxy(args.port, args.upstream, args.log, args.codex_header_compat,
-                  args.inject_reasoning_summary, args.fail_open)
+                  args.inject_reasoning_summary)
     stopped = asyncio.Event()
     loop = asyncio.get_running_loop()
     for sig in (signal.SIGTERM, signal.SIGINT):

--- a/tests/smoke_test_proxy.py
+++ b/tests/smoke_test_proxy.py
@@ -203,7 +203,7 @@ HTTPServer(('127.0.0.1', 19999), H).serve_forever()
         assert next((v for k, v in ups2.items() if k.lower() == "x-api-key"), None) == "existing-anthropic-key"
         print("DIALECT PASS: anthropic text-only bodies pass through byte-for-byte")
 
-        # ---- fail-closed: image bodies without vision config must 502, never forward ----
+        # ---- degraded: image bodies without vision config become a visible note ----
         env2 = {k: v for k, v in os.environ.items() if not k.startswith("VISION_")}
         pr2 = subprocess.Popen(
             [py, proxy_script, "--port", "19102", "--upstream", "http://127.0.0.1:19999",
@@ -226,11 +226,88 @@ HTTPServer(('127.0.0.1', 19999), H).serve_forever()
                 resp3 = conn3.getresponse()
                 resp3.read()
                 conn3.close()
-                assert resp3.status == 502, (path, resp3.status)
-            assert open("/tmp/up_body.json", "rb").read() == b"", "an image body leaked upstream"
-            print("FAIL-CLOSED PASS: image bodies in both dialects 502 without a vision config")
+                assert resp3.status == 200, (path, resp3.status)
+            upb3 = json.load(open("/tmp/up_body.json"))
+            assert "[vision unavailable:" in json.dumps(upb3, ensure_ascii=False), upb3
+            log3 = open("/tmp/ds_proxy_test2.log").read()
+            assert "image description failed" in log3 and "image rewrite degraded" in log3, log3
+            print("DEGRADED PASS: no vision config -> visible note forwarded, failure logged, never 502")
         finally:
             pr2.terminate()
+
+        # ---- broken vision API (401): request continues with a visible note ----
+        vision_src = r'''
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+class V(BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get('Content-Length', 0) or 0)
+        if n:
+            self.rfile.read(n)
+        self.send_response(401)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps({"error": {"message": "invalid api key"}}).encode())
+    def log_message(self, *a): pass
+HTTPServer(('127.0.0.1', 19998), V).serve_forever()
+'''
+        vision_file = "/tmp/ds_vision_401_server.py"
+        with open(vision_file, "w") as f:
+            f.write(vision_src)
+        vision_up = subprocess.Popen([py, vision_file],
+                                     stdout=open("/tmp/ds_vision_401.log", "w"), stderr=subprocess.STDOUT)
+        time.sleep(0.8)
+        env3 = {k: v for k, v in os.environ.items() if not k.startswith("VISION_")}
+        env3.update({"VISION_BASE_URL": "http://127.0.0.1:19998",
+                     "VISION_API_KEY": "bad-key", "VISION_MODEL": "vision-test"})
+        pr3 = subprocess.Popen(
+            [py, proxy_script, "--port", "19103", "--upstream", "http://127.0.0.1:19999",
+             "--log", "/tmp/ds_proxy_test3.log", "--skip-vision-config-check"],
+            stdout=open("/tmp/ds_proxy_proc3.log", "w"), stderr=subprocess.STDOUT, env=env3,
+        )
+        time.sleep(1.2)
+        try:
+            open("/tmp/up_body.json", "wb").close()
+            img_resp = ('{"model":"m","input":[{"type":"message","role":"user",'
+                        '"content":[{"type":"input_image","image_url":"data:image/png;base64,AAAA"}]}]}')
+            conn4 = http.client.HTTPConnection("127.0.0.1", 19103, timeout=5)
+            conn4.request("POST", "/responses", body=img_resp, headers={"Content-Type": "application/json"})
+            resp4 = conn4.getresponse()
+            resp4.read()
+            conn4.close()
+            up_resp = json.load(open("/tmp/up_body.json"))
+            resp_content = up_resp["input"][0]["content"]
+            assert resp4.status == 200, resp4.status
+            assert any("[vision unavailable:" in block.get("text", "") for block in resp_content), resp_content
+
+            open("/tmp/up_body.json", "wb").close()
+            anth_img = ('{"model":"m","messages":[{"role":"user","content":[{"type":"image",'
+                        '"source":{"type":"base64","media_type":"image/png","data":"AAAA"}}]}]}')
+            conn5 = http.client.HTTPConnection("127.0.0.1", 19103, timeout=5)
+            conn5.request("POST", "/v1/messages", body=anth_img, headers={"Content-Type": "application/json"})
+            resp5 = conn5.getresponse()
+            resp5.read()
+            conn5.close()
+            up_anth = json.load(open("/tmp/up_body.json"))
+            anth_content = up_anth["messages"][0]["content"]
+            assert resp5.status == 200, resp5.status
+            assert any("[vision unavailable:" in block.get("text", "") for block in anth_content), anth_content
+
+            open("/tmp/up_body.json", "wb").close()
+            text_only = '{"model":"m","input":"hi"}'
+            conn6 = http.client.HTTPConnection("127.0.0.1", 19103, timeout=5)
+            conn6.request("POST", "/responses", body=text_only, headers={"Content-Type": "application/json"})
+            resp6 = conn6.getresponse()
+            resp6.read()
+            conn6.close()
+            assert resp6.status == 200, resp6.status
+            assert open("/tmp/up_body.json", "rb").read() == text_only.encode(), "text-only body must pass through"
+            log3b = open("/tmp/ds_proxy_test3.log").read()
+            assert "Vision API HTTP 401" in log3b, "the 401 failure must be logged, never silent"
+            print("DEGRADED PASS: vision 401 -> note in both dialects, 401 logged; text-only stays 200")
+        finally:
+            pr3.terminate()
+            vision_up.terminate()
     finally:
         conn.close()
         up.terminate()

--- a/tests/test_anthropic_rewrite.py
+++ b/tests/test_anthropic_rewrite.py
@@ -214,14 +214,11 @@ def test_failure_is_not_forwarded():
     mod = _load_proxy()
     mod._image_desc_from_url = lambda _url, _prompt=None: None
     body = {"messages": [{"role": "user", "content": [dict(PNG)]}]}
-    try:
-        asyncio.run(mod._rewrite_image_inputs(body))
-    except mod.VisionError:
-        pass
-    else:
-        raise AssertionError("failed vision calls must raise instead of forwarding the image")
-    assert body["messages"][0]["content"][0]["type"] == "image"
-    print("PASS: a failed description still fails closed in the anthropic dialect")
+    assert asyncio.run(mod._rewrite_image_inputs(body))
+    text = body["messages"][0]["content"][-1]["text"]
+    assert text.startswith("[vision unavailable: "), text
+    assert "image description failed" in text, text
+    print("PASS: a failed description degrades to a visible note in the anthropic dialect")
 
 
 def test_text_only_anthropic_body_is_untouched():

--- a/tests/test_fail_open.py
+++ b/tests/test_fail_open.py
@@ -48,27 +48,6 @@ def test_vision_failure_degrades_by_default():
 
     content = body["input"][0]["content"]
     assert any(block.get("text", "").startswith("[vision proxy]") for block in content), content
-    text = content[-1]["text"]
-    assert text.startswith("[vision unavailable: "), text
-    assert "unauthorized" in text, text
-    assert "temporarily unavailable" in text, text
-    assert "[vision model description]" not in text, \
-        "an unavailable note is not a model description and must not wear its prefix"
-    print("PASS: a failed vision call degrades to a visible note by default")
-
-
-def test_failed_image_is_replaced_with_note():
-    mod = _load_proxy()
-
-    def boom(_url, _prompt=None):
-        raise mod.VisionError("Vision API HTTP 401: unauthorized")
-
-    mod._image_desc_from_url = boom
-    body = _responses_body("data:image/png;base64,AAA")
-    assert asyncio.run(mod._rewrite_image_inputs(body))
-
-    content = body["input"][0]["content"]
-    assert any(block.get("text", "").startswith("[vision proxy]") for block in content), content
     assert content[-1]["type"] == "input_text", content
     text = content[-1]["text"]
     assert text.startswith("[vision unavailable: "), text
@@ -76,7 +55,7 @@ def test_failed_image_is_replaced_with_note():
     assert "temporarily unavailable" in text, text
     assert "[vision model description]" not in text, \
         "an unavailable note is not a model description and must not wear its prefix"
-    print("PASS: the failed image is replaced with a note in place")
+    print("PASS: a failed vision call degrades to a visible note by default")
 
 
 def test_mixed_success_and_failure():
@@ -123,6 +102,5 @@ def test_anthropic_dialect():
 
 if __name__ == "__main__":
     test_vision_failure_degrades_by_default()
-    test_failed_image_is_replaced_with_note()
     test_mixed_success_and_failure()
     test_anthropic_dialect()

--- a/tests/test_fail_open.py
+++ b/tests/test_fail_open.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Unit test: --fail-open degrades vision failures instead of failing the request.
+"""Unit test: vision failures degrade to a visible note instead of failing the request.
 
-Without the flag, any failed vision call raises VisionError and the proxy answers
-the whole request -- including its plain-text parts -- with 502, blocking the
-conversation. With --fail-open, failed images are replaced by a
-"[vision unavailable: <reason>]" note so the text parts of the conversation can
-continue while the vision side is broken.
+A failed vision call (invalid key, network outage, upstream 5xx/429) used to
+raise VisionError and make the proxy answer the whole request -- including its
+plain-text parts -- with 502, blocking the conversation. By design, failed
+images are now replaced by a "[vision unavailable: <reason>]" note so the text
+parts of the conversation can continue while the vision side is broken. The
+failure is never silent: the reason travels with the note and the proxy logs it.
 """
 
 import asyncio
@@ -35,7 +36,7 @@ def _responses_body(image_url):
     ]}
 
 
-def test_default_remains_fail_closed():
+def test_vision_failure_degrades_by_default():
     mod = _load_proxy()
 
     def boom(_url, _prompt=None):
@@ -43,19 +44,20 @@ def test_default_remains_fail_closed():
 
     mod._image_desc_from_url = boom
     body = _responses_body("data:image/png;base64,AAA")
-    try:
-        asyncio.run(mod._rewrite_image_inputs(body))
-    except mod.VisionError as exc:
-        assert "unauthorized" in str(exc), exc
-        assert "not forwarded" in str(exc), exc
-    else:
-        raise AssertionError("without fail-open a failed vision call must raise")
-    assert body["input"][0]["content"][1]["type"] == "input_image", \
-        "the original image must not be rewritten when the call failed"
-    print("PASS: default behavior stays fail-closed")
+    assert asyncio.run(mod._rewrite_image_inputs(body))
+
+    content = body["input"][0]["content"]
+    assert any(block.get("text", "").startswith("[vision proxy]") for block in content), content
+    text = content[-1]["text"]
+    assert text.startswith("[vision unavailable: "), text
+    assert "unauthorized" in text, text
+    assert "temporarily unavailable" in text, text
+    assert "[vision model description]" not in text, \
+        "an unavailable note is not a model description and must not wear its prefix"
+    print("PASS: a failed vision call degrades to a visible note by default")
 
 
-def test_fail_open_replaces_failed_image_with_note():
+def test_failed_image_is_replaced_with_note():
     mod = _load_proxy()
 
     def boom(_url, _prompt=None):
@@ -63,7 +65,7 @@ def test_fail_open_replaces_failed_image_with_note():
 
     mod._image_desc_from_url = boom
     body = _responses_body("data:image/png;base64,AAA")
-    assert asyncio.run(mod._rewrite_image_inputs(body, fail_open=True))
+    assert asyncio.run(mod._rewrite_image_inputs(body))
 
     content = body["input"][0]["content"]
     assert any(block.get("text", "").startswith("[vision proxy]") for block in content), content
@@ -71,13 +73,13 @@ def test_fail_open_replaces_failed_image_with_note():
     text = content[-1]["text"]
     assert text.startswith("[vision unavailable: "), text
     assert "unauthorized" in text, text
-    assert text.endswith("]"), text
+    assert "temporarily unavailable" in text, text
     assert "[vision model description]" not in text, \
         "an unavailable note is not a model description and must not wear its prefix"
-    print("PASS: fail-open replaces the failed image with a note")
+    print("PASS: the failed image is replaced with a note in place")
 
 
-def test_fail_open_mixed_success_and_failure():
+def test_mixed_success_and_failure():
     mod = _load_proxy()
 
     def flaky(url, _prompt=None):
@@ -92,15 +94,15 @@ def test_fail_open_mixed_success_and_failure():
                      {"type": "input_image", "image_url": "data:image/png;base64,GOOD"},
                      {"type": "input_image", "image_url": "data:image/png;base64,BAD"}]},
     ]}
-    assert asyncio.run(mod._rewrite_image_inputs(body, fail_open=True))
+    assert asyncio.run(mod._rewrite_image_inputs(body))
 
     texts = [c["text"] for c in body["input"][0]["content"]]
     assert "[vision model description] GOOD-DESC" in texts, texts
     assert any(t.startswith("[vision unavailable: ") and "timeout" in t for t in texts), texts
-    print("PASS: in fail-open mode successes are described and failures degrade independently")
+    print("PASS: successes are described and failures degrade independently")
 
 
-def test_fail_open_anthropic_dialect():
+def test_anthropic_dialect():
     mod = _load_proxy()
 
     def boom(_url, _prompt=None):
@@ -108,7 +110,7 @@ def test_fail_open_anthropic_dialect():
 
     mod._image_desc_from_url = boom
     body = {"messages": [{"role": "user", "content": [dict(PNG)]}]}
-    assert asyncio.run(mod._rewrite_image_inputs(body, fail_open=True))
+    assert asyncio.run(mod._rewrite_image_inputs(body))
 
     content = body["messages"][0]["content"]
     assert content[0]["text"].startswith("[vision proxy]"), content
@@ -116,21 +118,11 @@ def test_fail_open_anthropic_dialect():
     text = content[-1]["text"]
     assert text.startswith("[vision unavailable: "), text
     assert "connection refused" in text, text
-    print("PASS: fail-open degrades Anthropic-dialect failures too")
-
-
-def test_fail_open_reaches_proxy():
-    mod = _load_proxy()
-    proxy = mod.Proxy(19100, "http://127.0.0.1:9", "", fail_open=True)
-    assert proxy.fail_open is True
-    default = mod.Proxy(19100, "http://127.0.0.1:9", "")
-    assert default.fail_open is False
-    print("PASS: the --fail-open flag is wired into the Proxy")
+    print("PASS: Anthropic-dialect failures degrade too")
 
 
 if __name__ == "__main__":
-    test_default_remains_fail_closed()
-    test_fail_open_replaces_failed_image_with_note()
-    test_fail_open_mixed_success_and_failure()
-    test_fail_open_anthropic_dialect()
-    test_fail_open_reaches_proxy()
+    test_vision_failure_degrades_by_default()
+    test_failed_image_is_replaced_with_note()
+    test_mixed_success_and_failure()
+    test_anthropic_dialect()

--- a/tests/test_fail_open.py
+++ b/tests/test_fail_open.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Unit test: --fail-open degrades vision failures instead of failing the request.
+
+Without the flag, any failed vision call raises VisionError and the proxy answers
+the whole request -- including its plain-text parts -- with 502, blocking the
+conversation. With --fail-open, failed images are replaced by a
+"[vision unavailable: <reason>]" note so the text parts of the conversation can
+continue while the vision side is broken.
+"""
+
+import asyncio
+import importlib.util
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+PNG = {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"}}
+
+
+def _load_proxy():
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        os.pardir, "codex-vision-proxy.py")
+    spec = importlib.util.spec_from_file_location("ds_proxy_fail_open_mod", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _responses_body(image_url):
+    return {"model": "user-configured-model", "input": [
+        {"type": "message", "role": "user",
+         "content": [{"type": "input_text", "text": "check this"},
+                     {"type": "input_image", "image_url": image_url}]},
+    ]}
+
+
+def test_default_remains_fail_closed():
+    mod = _load_proxy()
+
+    def boom(_url, _prompt=None):
+        raise mod.VisionError("Vision API HTTP 401: unauthorized")
+
+    mod._image_desc_from_url = boom
+    body = _responses_body("data:image/png;base64,AAA")
+    try:
+        asyncio.run(mod._rewrite_image_inputs(body))
+    except mod.VisionError as exc:
+        assert "unauthorized" in str(exc), exc
+        assert "not forwarded" in str(exc), exc
+    else:
+        raise AssertionError("without fail-open a failed vision call must raise")
+    assert body["input"][0]["content"][1]["type"] == "input_image", \
+        "the original image must not be rewritten when the call failed"
+    print("PASS: default behavior stays fail-closed")
+
+
+def test_fail_open_replaces_failed_image_with_note():
+    mod = _load_proxy()
+
+    def boom(_url, _prompt=None):
+        raise mod.VisionError("Vision API HTTP 401: unauthorized")
+
+    mod._image_desc_from_url = boom
+    body = _responses_body("data:image/png;base64,AAA")
+    assert asyncio.run(mod._rewrite_image_inputs(body, fail_open=True))
+
+    content = body["input"][0]["content"]
+    assert any(block.get("text", "").startswith("[vision proxy]") for block in content), content
+    assert content[-1]["type"] == "input_text", content
+    text = content[-1]["text"]
+    assert text.startswith("[vision unavailable: "), text
+    assert "unauthorized" in text, text
+    assert text.endswith("]"), text
+    assert "[vision model description]" not in text, \
+        "an unavailable note is not a model description and must not wear its prefix"
+    print("PASS: fail-open replaces the failed image with a note")
+
+
+def test_fail_open_mixed_success_and_failure():
+    mod = _load_proxy()
+
+    def flaky(url, _prompt=None):
+        if "GOOD" in url:
+            return "GOOD-DESC"
+        raise mod.VisionError("vision timeout")
+
+    mod._image_desc_from_url = flaky
+    body = {"model": "user-configured-model", "input": [
+        {"type": "message", "role": "user",
+         "content": [{"type": "input_text", "text": "compare"},
+                     {"type": "input_image", "image_url": "data:image/png;base64,GOOD"},
+                     {"type": "input_image", "image_url": "data:image/png;base64,BAD"}]},
+    ]}
+    assert asyncio.run(mod._rewrite_image_inputs(body, fail_open=True))
+
+    texts = [c["text"] for c in body["input"][0]["content"]]
+    assert "[vision model description] GOOD-DESC" in texts, texts
+    assert any(t.startswith("[vision unavailable: ") and "timeout" in t for t in texts), texts
+    print("PASS: in fail-open mode successes are described and failures degrade independently")
+
+
+def test_fail_open_anthropic_dialect():
+    mod = _load_proxy()
+
+    def boom(_url, _prompt=None):
+        raise mod.VisionError("Vision API network error: connection refused")
+
+    mod._image_desc_from_url = boom
+    body = {"messages": [{"role": "user", "content": [dict(PNG)]}]}
+    assert asyncio.run(mod._rewrite_image_inputs(body, fail_open=True))
+
+    content = body["messages"][0]["content"]
+    assert content[0]["text"].startswith("[vision proxy]"), content
+    assert content[-1]["type"] == "text", content
+    text = content[-1]["text"]
+    assert text.startswith("[vision unavailable: "), text
+    assert "connection refused" in text, text
+    print("PASS: fail-open degrades Anthropic-dialect failures too")
+
+
+def test_fail_open_reaches_proxy():
+    mod = _load_proxy()
+    proxy = mod.Proxy(19100, "http://127.0.0.1:9", "", fail_open=True)
+    assert proxy.fail_open is True
+    default = mod.Proxy(19100, "http://127.0.0.1:9", "")
+    assert default.fail_open is False
+    print("PASS: the --fail-open flag is wired into the Proxy")
+
+
+if __name__ == "__main__":
+    test_default_remains_fail_closed()
+    test_fail_open_replaces_failed_image_with_note()
+    test_fail_open_mixed_success_and_failure()
+    test_fail_open_anthropic_dialect()
+    test_fail_open_reaches_proxy()

--- a/tests/test_image_rewrite_shapes.py
+++ b/tests/test_image_rewrite_shapes.py
@@ -98,14 +98,12 @@ def test_failure_is_not_forwarded():
     body = {"input": [{"type": "message", "content": [
         {"type": "input_image", "image_url": "data:image/png;base64,AAA"}
     ]}]}
-    try:
-        asyncio.run(mod._rewrite_image_inputs(body))
-    except mod.VisionError:
-        pass
-    else:
-        raise AssertionError("failed vision calls must raise instead of forwarding the image")
-    assert body["input"][0]["content"][0]["type"] == "input_image"
-    print("PASS: failed vision call is not converted into an error description")
+    assert asyncio.run(mod._rewrite_image_inputs(body))
+    text = body["input"][0]["content"][-1]["text"]
+    assert text.startswith("[vision unavailable: "), text
+    assert "image description failed" in text, text
+    assert "[vision model description]" not in text, text
+    print("PASS: failed vision call degrades to a visible note, never a fake description")
 
 
 def test_failure_reason_is_included():
@@ -118,14 +116,11 @@ def test_failure_reason_is_included():
     body = {"input": [{"type": "message", "content": [
         {"type": "input_image", "image_url": "data:image/png;base64,AAA"}
     ]}]}
-    try:
-        asyncio.run(mod._rewrite_image_inputs(body))
-    except mod.VisionError as exc:
-        assert "balance insufficient" in str(exc), exc
-        assert "not forwarded" in str(exc), exc
-    else:
-        raise AssertionError("failed vision calls must raise")
-    print("PASS: failure reason is included in the raised error")
+    assert asyncio.run(mod._rewrite_image_inputs(body))
+    text = body["input"][0]["content"][-1]["text"]
+    assert "balance insufficient" in text, text
+    assert "temporarily unavailable" in text, text
+    print("PASS: failure reason is included in the visible note")
 
 
 def test_channel_note_lands_once_on_the_first_image():


### PR DESCRIPTION
## What

A failed vision call — invalid key, network outage, upstream 5xx/429 — used to raise `VisionError` inside the image-rewrite path, and the proxy answered the **whole** request with 502. Since Codex carries images inside the request body, one broken vision call blocked the entire conversation, including pure-text turns that never needed the vision model.

**Design decision (reviewed):** fail-closed 502 blocking the whole conversation was a design *side effect*, not the intended contract. The correct behavior is:

- when image viewing fails, the request continues and the model sees a `[vision unavailable: <reason>]` note in place of the image;
- the note explicitly tells the model to let the user know the vision tool is temporarily unavailable;
- the failure is **never silent**: the reason travels with the note and the proxy logs `image description failed` / `image rewrite degraded`;
- pure-text parts of the conversation are unaffected in both dialects (OpenAI Responses / Codex and Anthropic Messages / Claude Code).

Because degradation is the correct default, the opt-in `--fail-open` flag from the original draft is removed — no configuration is needed. Per maintainer preference, no README / AGENT_INSTALL documentation changes are included.

## Commits

- `feat: add --fail-open so vision failures degrade instead of 502` (from closed #3)
- `fix: make vision-failure degradation the default, drop the opt-in flag`

## Tests

- `tests/test_fail_open.py` (new): failure degrades by default in both dialects; mixed success/failure degrades only the failed images; the note carries the reason and the "tell the user" instruction.
- `tests/test_image_rewrite_shapes.py` / `tests/test_anthropic_rewrite.py`: failure tests updated from "must raise" to "degrades to a visible note, never a fake description".
- `tests/smoke_test_proxy.py` (extended): end-to-end — proxy with no vision config and with a vision API returning 401: image requests answer 200 with the note reaching the upstream, the failure lines are present in the proxy log, text-only requests stay 200 byte-for-byte.
- Full suite: py_compile, unit tests, smoke, `git diff --check` — all pass on this branch.

Supersedes #3 (closed).
