### PR TITLE
test: cover non-Codex dialect passthrough through the apply_patch bridge

### DIFF
--- a/tests/test_apply_patch_bridge.py
+++ b/tests/test_apply_patch_bridge.py
@@ -260,15 +260,7 @@ def main():
         out = mod._rewrite_sse_frame(f, state)
         ok = ok and len(out) == 1 and out[0] == f
     check("anthropic sse passthrough", ok)
-    # c) Chat Completions request: flat function apply_patch keeps a valid
-    # shape (description normalized, structure intact); nested shape skipped.
-    chat_req = {"tools": [{"type": "function", "name": "apply_patch", "description": "orig",
-                           "parameters": {"type": "object", "properties": {"input": {"type": "string"}}}}]}
-    check("chat flat apply_patch normalized", mod._rewrite_apply_patch_tool(chat_req) is True
-          and chat_req["tools"][0]["type"] == "function"
-          and chat_req["tools"][0]["name"] == "apply_patch"
-          and chat_req["tools"][0]["parameters"]["properties"]["input"]["type"] == "string")
-    # d) Chat Completions SSE frames have no top-level "type" -> passthrough.
+    # c) Chat Completions SSE frames have no top-level "type" -> passthrough.
     chat_frames = [
         b'data: {"choices": [{"delta": {"tool_calls": [{"index": 0, "id": "c", "function": {"name": "apply_patch", "arguments": "{\\"patch\\": \\"x\\"}"}}]}}]}\n\n',
         b'data: {"choices": [{"delta": {"content": "done"}}]}\n\n',
@@ -280,8 +272,13 @@ def main():
         out = mod._rewrite_sse_frame(f, state)
         ok = ok and len(out) == 1 and out[0] == f
     check("chat sse passthrough", ok)
-    # e) Non-streaming chat JSON response (choices shape) untouched.
-    chat_json = b'{"choices": [{"message": {"role": "assistant", "content": "ok"}}]}'
+    # d) Non-streaming chat JSON response untouched even when it carries an
+    # apply_patch tool_call (bridge only rewrites top-level "output" lists).
+    chat_json = (b'{"choices": [{"message": {"role": "assistant", "content": null, "tool_calls": '
+                 b'[{"id": "call_1", "type": "function", "function": {"name": "apply_patch", '
+                 b'"arguments": "{\\"patch\\": \\"x\\"}"}}]}}]}')
+    parsed_chat = json.loads(chat_json)
+    check("chat json fixture is real", parsed_chat["choices"][0]["message"]["tool_calls"][0]["function"]["name"] == "apply_patch")
     check("chat json response untouched", mod._rewrite_apply_patch_response_json(chat_json) is chat_json)
 
     print("----")

--- a/tests/test_apply_patch_bridge.py
+++ b/tests/test_apply_patch_bridge.py
@@ -242,6 +242,48 @@ def main():
     buffered = mod._rewrite_sse_body(raw)
     check("buffered rewrite == streaming rewrite", buffered == outputs[0])
 
+    # Non-Codex dialects must pass through the bridge untouched.
+    # a) Anthropic Messages tools carry no "type" field -> never matched.
+    anthropic_req = {"model": "opus", "tools": [{"name": "apply_patch", "input_schema": {"type": "object"}}], "messages": []}
+    check("anthropic request untouched", mod._rewrite_apply_patch_tool(anthropic_req) is False
+          and anthropic_req["tools"][0]["name"] == "apply_patch"
+          and "input_schema" in anthropic_req["tools"][0])
+    # b) Anthropic SSE frames (content_block_*) pass through byte-identical.
+    anthro_frames = [
+        b'event: content_block_start\ndata: {"type": "content_block_start", "index": 0, "content_block": {"type": "text"}}\n\n',
+        b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}}\n\n',
+        b'event: message_stop\ndata: {"type": "message_stop"}\n\n',
+    ]
+    state = {"pending": {}, "completed": False}
+    ok = True
+    for f in anthro_frames:
+        out = mod._rewrite_sse_frame(f, state)
+        ok = ok and len(out) == 1 and out[0] == f
+    check("anthropic sse passthrough", ok)
+    # c) Chat Completions request: flat function apply_patch keeps a valid
+    # shape (description normalized, structure intact); nested shape skipped.
+    chat_req = {"tools": [{"type": "function", "name": "apply_patch", "description": "orig",
+                           "parameters": {"type": "object", "properties": {"input": {"type": "string"}}}}]}
+    check("chat flat apply_patch normalized", mod._rewrite_apply_patch_tool(chat_req) is True
+          and chat_req["tools"][0]["type"] == "function"
+          and chat_req["tools"][0]["name"] == "apply_patch"
+          and chat_req["tools"][0]["parameters"]["properties"]["input"]["type"] == "string")
+    # d) Chat Completions SSE frames have no top-level "type" -> passthrough.
+    chat_frames = [
+        b'data: {"choices": [{"delta": {"tool_calls": [{"index": 0, "id": "c", "function": {"name": "apply_patch", "arguments": "{\\"patch\\": \\"x\\"}"}}]}}]}\n\n',
+        b'data: {"choices": [{"delta": {"content": "done"}}]}\n\n',
+        b'data: [DONE]\n\n',
+    ]
+    state = {"pending": {}, "completed": False}
+    ok = True
+    for f in chat_frames:
+        out = mod._rewrite_sse_frame(f, state)
+        ok = ok and len(out) == 1 and out[0] == f
+    check("chat sse passthrough", ok)
+    # e) Non-streaming chat JSON response (choices shape) untouched.
+    chat_json = b'{"choices": [{"message": {"role": "assistant", "content": "ok"}}]}'
+    check("chat json response untouched", mod._rewrite_apply_patch_response_json(chat_json) is chat_json)
+
     print("----")
     if failures:
         print("FAILURES:", failures)


### PR DESCRIPTION
Follow-up to #6: the apply_patch bridge is whitelist-only by design, but nothing asserted that non-Codex traffic stays byte-identical. Adds unit coverage for:

- Anthropic Messages (Claude Code) request tools — carry no `type` field, never matched by the bridge
- Anthropic SSE frames (`content_block_*`) — byte-identical passthrough
- Chat Completions SSE frames with `apply_patch` tool-call deltas — byte-identical passthrough
- Non-streaming Chat Completions JSON whose `choices[].message.tool_calls` contains `apply_patch` — byte-identical (the bridge only rewrites top-level `output` lists)

The fixture is asserted to be real JSON carrying `apply_patch` so the passthrough checks cannot false-green on a malformed fixture. Flat/nested Chat Completions request shapes were already covered on main and are intentionally not duplicated here.

Verified additionally with a real Claude Code CLI (2.1.218) pointed at the proxy: the Anthropic request is forwarded losslessly to the upstream gateway (`POST /v1/messages?beta=true`); full completion was limited by the local gateway's account quota (`No available accounts` — reproduced on a direct connection, unrelated to the proxy). Other agents in this environment (Claude Code, OpenCode) route through the same gateway; Pi/OPi use native extensions and never touch this proxy.

Reviewed by three adversarial review passes (H1–H5) plus a dedicated PR review; all 29 bridge tests PASS, full suite matches main (38 passed; the 7 `test_dominant_colors.py` errors are a pre-existing missing `mod` fixture on main).
