### PR TITLE
fix: run bare shebang glance scripts via the interpreter on Windows

### DIFF
--- a/skills/vision-tools/scripts/long_screenshot_ocr.py
+++ b/skills/vision-tools/scripts/long_screenshot_ocr.py
@@ -434,7 +434,20 @@ def prune_stale_chunk_files(chunks_dir: Path, chunks: Sequence[Chunk]) -> None:
 
 
 def command_for_path(path: Path) -> list[str]:
-    if path.suffix.lower() == ".py" or (os.name != "nt" and not os.access(path, os.X_OK)):
+    if path.suffix.lower() == ".py":
+        return [sys.executable, str(path)]
+    if os.name == "nt":
+        # Windows cannot exec a shebang script directly; a bare script on PATH
+        # (or the repo's own bin/glance) must be run through the interpreter.
+        try:
+            with open(path, "rb") as handle:
+                first = handle.readline().decode("utf-8", errors="replace")
+        except OSError:
+            first = ""
+        if first.lstrip().startswith("#!") and "python" in first.lower():
+            return [sys.executable, str(path)]
+        return [str(path)]
+    if not os.access(path, os.X_OK):
         return [sys.executable, str(path)]
     return [str(path)]
 

--- a/skills/vision-tools/scripts/long_screenshot_ocr.py
+++ b/skills/vision-tools/scripts/long_screenshot_ocr.py
@@ -434,14 +434,17 @@ def prune_stale_chunk_files(chunks_dir: Path, chunks: Sequence[Chunk]) -> None:
 
 
 def command_for_path(path: Path) -> list[str]:
-    if path.suffix.lower() == ".py":
+    suffix = path.suffix.lower()
+    if suffix in {".py", ".pyw"}:
         return [sys.executable, str(path)]
     if os.name == "nt":
         # Windows cannot exec a shebang script directly; a bare script on PATH
         # (or the repo's own bin/glance) must be run through the interpreter.
+        if suffix:
+            return [str(path)]
         try:
             with open(path, "rb") as handle:
-                first = handle.readline().decode("utf-8", errors="replace")
+                first = handle.readline(256).decode("utf-8", errors="replace")
         except OSError:
             first = ""
         if first.lstrip().startswith("#!") and "python" in first.lower():

--- a/tests/test_long_screenshot_ocr.py
+++ b/tests/test_long_screenshot_ocr.py
@@ -252,6 +252,26 @@ def write_stub(path: Path, body: str) -> None:
         )
 
 
+def test_windows_command_for_path(mod):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        bare_script = Path(temp_dir) / "glance"
+        bare_script.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+        command_wrapper = Path(temp_dir) / "glance.cmd"
+        command_wrapper.write_text("@echo off\r\n", encoding="ascii")
+
+        real_os = mod.os
+
+        class WindowsOS:
+            name = "nt"
+
+        mod.os = WindowsOS
+        try:
+            assert mod.command_for_path(bare_script) == [sys.executable, str(bare_script)]
+            assert mod.command_for_path(command_wrapper) == [str(command_wrapper)]
+        finally:
+            mod.os = real_os
+
+
 def test_cli_split_ocr_merge_and_resume():
     with tempfile.TemporaryDirectory() as temp_dir_raw:
         temp_dir = Path(temp_dir_raw)
@@ -468,6 +488,7 @@ def main():
     test_chat_json_render_and_message_merge(mod)
     test_chat_overlap_uses_richer_boundary_messages(mod)
     test_resume_fingerprint_tracks_mode_and_prompt(mod)
+    test_windows_command_for_path(mod)
     test_cli_split_ocr_merge_and_resume()
     test_cli_chat_mode_uses_structured_messages()
     test_cli_chat_mode_retries_invalid_json_once()

--- a/tests/test_long_screenshot_ocr.py
+++ b/tests/test_long_screenshot_ocr.py
@@ -242,6 +242,14 @@ def test_resume_fingerprint_tracks_mode_and_prompt(mod):
 def write_stub(path: Path, body: str) -> None:
     path.write_text("#!/usr/bin/env python3\n" + body, encoding="utf-8")
     path.chmod(0o755)
+    if os.name == "nt":
+        # Windows cannot exec a shebang script and shutil.which only matches
+        # PATHEXT suffixes, so also install a .cmd wrapper that runs the stub.
+        cmd_file = path.with_suffix(".cmd")
+        cmd_file.write_text(
+            f'@echo off\r\n"{sys.executable}" "{path.resolve()}" %*\r\n',
+            encoding="ascii",
+        )
 
 
 def test_cli_split_ocr_merge_and_resume():

--- a/tests/test_vision_client.py
+++ b/tests/test_vision_client.py
@@ -140,16 +140,17 @@ def main():
                 "VISION_MODEL=fixture-model\n"
             )
             isolated_env = dict(environment, HOME=raw)
+            glance = Path(__file__).resolve().parent.parent / "bin/glance"
+            glance_cmd = [sys.executable, str(glance)] if os.name == "nt" else [str(glance)]
             result = subprocess.run(
-                [str(Path(__file__).resolve().parent.parent / "bin/glance"), str(image), "-q", "图里有什么？"],
+                [*glance_cmd, str(image), "-q", "图里有什么？"],
                 env=isolated_env, cwd=raw, text=True, capture_output=True, check=True,
             )
             assert result.stdout.strip() == "fixture answer"
 
             Handler.calls, Handler.statuses, Handler.bodies = 0, [200], []
             result = subprocess.run(
-                [str(Path(__file__).resolve().parent.parent / "bin/glance"), str(image), str(image),
-                 "-q", "differences?"],
+                [*glance_cmd, str(image), str(image), "-q", "differences?"],
                 env=isolated_env, cwd=raw, text=True, capture_output=True, check=True,
             )
             assert result.stdout.strip() == "fixture answer"


### PR DESCRIPTION
## Problem

On Windows, `CreateProcess` cannot exec a bare shebang script. Three places hit this and failed with `WinError 193`:

1. `command_for_path()` in `long_screenshot_ocr.py` only special-cased `.py` files and POSIX non-executable files, so a bare script on PATH (the repo's own `bin/glance`, or a test stub) was passed straight to `CreateProcess`.
2. `test_long_screenshot_ocr.py`'s `write_stub` installs the stub as a bare file; on Windows `shutil.which` only matches PATHEXT suffixes, so the CLI tests could never find it.
3. `test_vision_client.py` invokes `bin/glance` directly via `subprocess.run`, which fails on Windows for the same reason — this test is in the Required Verification list and could not run on Windows at all.

## Implementation

- `command_for_path()`: on `nt`, sniff the first line for a python shebang and route such files through `sys.executable`. Non-script files (`.cmd`, `.exe`) still run directly. POSIX behavior is unchanged.
- `write_stub()`: on `nt`, also install a `.cmd` wrapper that runs the stub through the current interpreter, so the CLI tests are findable by `shutil.which` and executable.
- `test_vision_client.py`: prefix `bin/glance` with `sys.executable` on `nt`.

All three changes are the same fix (Windows cannot exec bare python scripts) applied consistently.

## Verification

```
python -m py_compile vision_proxy.py vision_client.py ground.py detect.py bin/glance bin/trace bin/crop   PASS
python tests/test_image_rewrite_shapes.py    PASS
python tests/test_focus_hint.py              PASS
python tests/test_anthropic_rewrite.py       PASS
python tests/smoke_test_proxy.py             SMOKE PASS
python tests/test_vision_client.py           PASS
python tests/test_long_screenshot_ocr.py     PASS
node tests/test_extensions.mjs               PASS
git diff --check                             clean
```
