### PR TITLE
fix: preserve trace SVG byte contract on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           python tests/smoke_test_egress_failover.py
           python tests/test_vision_client.py
           python tests/test_restore_ui_playbook.py
+          python tests/test_trace.py
 
   python-egress-windows:
     runs-on: windows-latest
@@ -47,7 +48,9 @@ jobs:
       - name: Compile proxy entry points
         run: python -m py_compile vision_proxy.py vision_client.py tests/smoke_test_egress_failover.py
       - name: Run Windows egress smoke test
-        run: python tests/smoke_test_egress_failover.py
+        run: |
+          python tests/smoke_test_egress_failover.py
+          python tests/test_trace.py
 
   extensions:
     runs-on: ubuntu-latest

--- a/bin/trace
+++ b/bin/trace
@@ -34,6 +34,12 @@ def truncate_decimals(svg, places=2):
     return re.sub(r"-?\d+\.\d{3,}", lambda m: f"{float(m.group()):.{places}f}", svg)
 
 
+def write_svg(path, svg):
+    """Write the exact UTF-8 payload whose byte count is reported to callers."""
+    payload = svg.encode("utf-8")
+    return Path(path).expanduser().write_bytes(payload)
+
+
 def prepare_input(path, region, scale):
     """Crop/upscale with Pillow when asked; return the path vtracer reads and the scale used.
 
@@ -113,8 +119,8 @@ def main():
               "--color is a last resort: on an anti-aliased image it splits every gray "
               "level into its own path.", file=sys.stderr)
     if args.output:
-        Path(args.output).expanduser().write_text(svg)
-        print(f"wrote {args.output} ({len(svg)} bytes, {paths} paths, traced at {scale}x)")
+        bytes_written = write_svg(args.output, svg)
+        print(f"wrote {args.output} ({bytes_written} bytes, {paths} paths, traced at {scale}x)")
     else:
         print(svg)
 

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -37,6 +37,18 @@ def main():
     assert "7.891011" not in truncated and "7.89" in truncated
     print("PASS: background stripping and decimal truncation")
 
+    with tempfile.TemporaryDirectory() as raw:
+        out = os.path.join(raw, "multiline.svg")
+        multiline = "<svg>\n<title>几何</title>\n<path/>\n</svg>\n"
+        reported = mod.write_svg(out, multiline)
+        payload = multiline.encode("utf-8")
+        with open(out, "rb") as handle:
+            written = handle.read()
+        assert written == payload, "SVG output must preserve LF bytes on every platform"
+        assert reported == len(written), "reported bytes must equal the file size on disk"
+        assert reported > len(multiline), "the byte contract must not use Unicode character count"
+        print("PASS: multiline SVG output preserves exact UTF-8 bytes")
+
     try:
         import vtracer  # noqa: F401
         from PIL import Image


### PR DESCRIPTION
## Problem

On Windows, `Path.write_text()` translates each SVG `\n` to `\r\n`, while `trace` reports `len(svg)`. Multi-line output therefore reports fewer bytes than were written, and strict consumers reject the artifact. `len(svg)` is also a character count rather than a UTF-8 byte count.

Downstream context: Anionex/dsh-vision-toolkit#8.

## Fix

- encode the finalized SVG once as UTF-8 and write those exact bytes with `Path.write_bytes()`
- report the actual byte count returned by the write operation, keeping the on-disk artifact and stdout contract identical
- cover multi-line LF preservation and non-ASCII byte counting without requiring optional tracing dependencies
- run the focused trace regression in both the Ubuntu core matrix and the Windows CI job

## Verification

- `python3 -m py_compile vision_proxy.py vision_client.py ground.py detect.py bin/glance bin/trace bin/crop`
- required core tests: image rewrite, focus hint, Anthropic rewrite, proxy smoke, and vision client — passed
- `python3 tests/test_trace.py` — focused unit regression passed
- `uv run --with pillow --with vtracer python tests/test_trace.py` — full trace CLI path passed
- `git diff --check`
- GitHub CI: Python 3.11, Python 3.14, Windows, and extensions — passed

This is a non-UI CLI contract fix; there is no browser path. The byte-for-byte assertion and Windows CI execution cover the affected behavior.
