### PR TITLE
fix: handle Qwen and Gemini grounding coordinate orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable user-facing changes to agent-vision-toolkit are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Parse Qwen-family grounding boxes as `x0,y0,x1,y1` while preserving Gemini's `y0,x0,y1,x1` convention, with `VISION_BOX_ORDER` available for custom providers.
+- Reject truncated bounding-box JSON instead of silently returning the complete objects that happened to appear before truncation.
+- Avoid duplicating `every distinct` and visible-text instructions when callers pass a complete detect category.
+
 ## [0.2.0] - 2026-08-14
 
 ### Added

--- a/detect.py
+++ b/detect.py
@@ -16,8 +16,12 @@ DEFAULT_CATEGORY = ("UI element (buttons, links, inputs, icons, labels, "
 
 
 def build_target(category: str | None) -> str:
-    return (f"every distinct {category or DEFAULT_CATEGORY} — "
-            "include the exact visible text in each label")
+    target = (category or DEFAULT_CATEGORY).strip()
+    if not target.lower().startswith("every distinct "):
+        target = f"every distinct {target}"
+    if "exact visible text" not in target.lower():
+        target += " — include the exact visible text in each label"
+    return target
 
 
 def format_inventory(matches, width: int, height: int) -> list[str]:

--- a/ground.py
+++ b/ground.py
@@ -4,6 +4,7 @@ import argparse
 import base64
 import io
 import json
+import os
 import re
 import sys
 from dataclasses import dataclass
@@ -28,12 +29,23 @@ class GroundError(Exception):
     pass
 
 
-def build_prompt(target: str) -> str:
+def coordinate_order() -> str:
+    configured = os.environ.get("VISION_BOX_ORDER", "").strip().lower()
+    if configured:
+        if configured not in {"xyxy", "yxyx"}:
+            raise GroundError("VISION_BOX_ORDER must be either xyxy or yxyx")
+        return configured
+    model = os.environ.get("VISION_MODEL", "").lower()
+    return "xyxy" if "qwen" in model else "yxyx"
+
+
+def build_prompt(target: str, box_order: str = "yxyx") -> str:
+    coordinates = "[x0, y0, x1, y1]" if box_order == "xyxy" else "[y0, x0, y1, x1]"
     return (
         "Locate every visible object or region matching this target:\n"
         f"{target}\n\n"
         'Return only a JSON array. Each item must contain "box_2d" as '
-        '[y0, x0, y1, x1] on a 0-1000 grid and "label" as a short description. '
+        f'{coordinates} on a 0-1000 grid and "label" as a short description. '
         "Use tight boxes in the original image. Return [] when nothing matches."
     )
 
@@ -70,6 +82,8 @@ def _items(text: str) -> list[Any]:
     try:
         payload = json.loads(cleaned)
     except json.JSONDecodeError:
+        if cleaned.count("```") % 2 or _has_unclosed_json(cleaned):
+            raise GroundError("Vision API bounding-box JSON was truncated or incomplete") from None
         fallback = _fallback_items(cleaned)
         if fallback:
             return fallback
@@ -83,7 +97,37 @@ def _items(text: str) -> list[Any]:
     raise GroundError("Vision API returned an incompatible bounding-box JSON structure")
 
 
-def _normalize_box(item: dict[str, Any], width: int, height: int) -> tuple[int, int, int, int] | None:
+def _has_unclosed_json(text: str) -> bool:
+    start_positions = [position for position in (text.find("["), text.find("{")) if position >= 0]
+    if not start_positions:
+        return False
+    stack = []
+    in_string = False
+    escaped = False
+    pairs = {"]": "[", "}": "{"}
+    for character in text[min(start_positions):]:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character in "[{":
+            stack.append(character)
+        elif character in "]}":
+            if not stack or stack[-1] != pairs[character]:
+                return False
+            stack.pop()
+    return bool(stack)
+
+
+def _normalize_box(
+    item: dict[str, Any], width: int, height: int, box_order: str = "yxyx",
+) -> tuple[int, int, int, int] | None:
     raw = item.get("box_2d")
     if not isinstance(raw, list):
         for key in ("bbox_2d", "box2d", "bbox", "box"):
@@ -93,9 +137,13 @@ def _normalize_box(item: dict[str, Any], width: int, height: int) -> tuple[int, 
     if not isinstance(raw, list) or len(raw) != 4:
         return None
     try:
-        y0, x0, y1, x1 = (float(value) for value in raw)
+        values = tuple(float(value) for value in raw)
     except (TypeError, ValueError):
         return None
+    if box_order == "xyxy":
+        x0, y0, x1, y1 = values
+    else:
+        y0, x0, y1, x1 = values
     if x0 > x1:
         x0, x1 = x1, x0
     if y0 > y1:
@@ -109,12 +157,14 @@ def _normalize_box(item: dict[str, Any], width: int, height: int) -> tuple[int, 
     return box if box[2] > box[0] and box[3] > box[1] else None
 
 
-def parse_matches(text: str, width: int, height: int, target: str) -> list[Match]:
+def parse_matches(
+    text: str, width: int, height: int, target: str, box_order: str = "yxyx",
+) -> list[Match]:
     matches = []
     for item in _items(text):
         if not isinstance(item, dict):
             continue
-        box = _normalize_box(item, width, height)
+        box = _normalize_box(item, width, height, box_order)
         if box is None:
             continue
         label = str(item.get("label") or item.get("caption") or item.get("description") or target).strip()
@@ -156,8 +206,9 @@ def locate(image_path: Path, target: str, region: str | None = None) -> list[Mat
         width_used, height_used = box[2] - box[0], box[3] - box[1]
     # 8192 leaves room for exhaustive targets ("every UI element"): a dense
     # screen can emit dozens of boxes and 2048 truncated the JSON mid-array.
-    response = describe_image(url, build_prompt(target), max_tokens=8192)
-    matches = parse_matches(response, width_used, height_used, target)
+    box_order = coordinate_order()
+    response = describe_image(url, build_prompt(target, box_order), max_tokens=8192)
+    matches = parse_matches(response, width_used, height_used, target, box_order)
     if box is None:
         return matches
     # Matches were parsed in crop coordinates; report them in the original image.

--- a/skills/vision-tools/SKILL.md
+++ b/skills/vision-tools/SKILL.md
@@ -109,6 +109,12 @@ ground <image> "<target>" --region X1,Y1,X2,Y2
 Output: `x1: .., y1: .., x2: .., y2: ..` in original-image pixels — with
 `--region` too (crop hits are mapped back).
 
+Provider-native 0-1000 boxes do not all use the same array order: Gemini uses
+`[y0, x0, y1, x1]`, while Qwen3-VL, Qwen3.5, and Qwen3.6 use
+`[x0, y0, x1, y1]`. Grounding code must select the order by model family (or
+an explicit override) before scaling to pixels; never parse every provider as
+Gemini-style `yxyx`.
+
 If several boxes come back numbered, your description matched more than
 one element rather than picking out a single thing. Narrow it with what
 distinguishes the one you mean — its text, its position, the block it sits

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -18,6 +18,8 @@ def test_target_construction():
     assert "every distinct UI element" in detect.build_target(None)
     assert "exact visible text" in detect.build_target(None)
     assert "every distinct buttons" in detect.build_target("buttons")
+    complete = "every distinct UI element — include the exact visible text in each label"
+    assert detect.build_target(complete) == complete
 
 
 def test_region_boxes_map_back_to_original_coordinates():

--- a/tests/test_ground.py
+++ b/tests/test_ground.py
@@ -4,6 +4,7 @@
 import subprocess
 import sys
 import tempfile
+import os
 from pathlib import Path
 
 from PIL import Image
@@ -25,6 +26,45 @@ def test_box_parsing():
     ]
 
     assert ground.parse_matches("[]", 80, 60, "target") == []
+
+
+def test_qwen_xyxy_box_parsing_on_non_square_image():
+    text = '[{"box_2d": [333, 34, 827, 82], "label": "title"}]'
+    assert ground.parse_matches(text, 1200, 675, "target", "xyxy") == [
+        ground.Match("title", (400, 23, 992, 55))
+    ]
+
+
+def test_coordinate_order_uses_model_family_and_override():
+    original_model = os.environ.get("VISION_MODEL")
+    original_order = os.environ.get("VISION_BOX_ORDER")
+    try:
+        os.environ["VISION_MODEL"] = "qwen/qwen3.6-27b"
+        os.environ.pop("VISION_BOX_ORDER", None)
+        assert ground.coordinate_order() == "xyxy"
+        os.environ["VISION_MODEL"] = "gemini-2.5-flash"
+        assert ground.coordinate_order() == "yxyx"
+        os.environ["VISION_BOX_ORDER"] = "xyxy"
+        assert ground.coordinate_order() == "xyxy"
+    finally:
+        if original_model is None:
+            os.environ.pop("VISION_MODEL", None)
+        else:
+            os.environ["VISION_MODEL"] = original_model
+        if original_order is None:
+            os.environ.pop("VISION_BOX_ORDER", None)
+        else:
+            os.environ["VISION_BOX_ORDER"] = original_order
+
+
+def test_truncated_json_does_not_return_partial_matches():
+    truncated = '```json\n[{"box_2d": [0, 0, 100, 100], "label": "first"}, {"box_2d": [100'
+    try:
+        ground.parse_matches(truncated, 1200, 675, "target")
+    except ground.GroundError as exc:
+        assert "truncated or incomplete" in str(exc)
+    else:
+        raise AssertionError("truncated bounding-box JSON must fail closed")
 
 
 def test_shared_vision_request():
@@ -67,6 +107,9 @@ def test_output_format():
 
 def main():
     test_box_parsing()
+    test_qwen_xyxy_box_parsing_on_non_square_image()
+    test_coordinate_order_uses_model_family_and_override()
+    test_truncated_json_does_not_return_partial_matches()
     test_shared_vision_request()
     test_output_format()
     subprocess.run([sys.executable, "bin/ground", "--help"], check=True, stdout=subprocess.DEVNULL)


### PR DESCRIPTION
## Summary

- select Gemini `yxyx` versus Qwen-family `xyxy` grounding coordinates by model family, with `VISION_BOX_ORDER` override support
- reject truncated bounding-box JSON instead of returning partial matches
- make detect target construction idempotent
- document the provider coordinate conventions in the `vision-tools` Skill

## Verification

- `python3 tests/test_ground.py`
- `python3 tests/test_detect.py`
- `python3 -m py_compile ground.py detect.py`
- live Qwen3.6 grounding on a 1200x675 image produced a horizontal top-title box after `xyxy` parsing
