### PR TITLE
feat: add full-page captures and quota handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Compile Python entry points
-        run: python -m py_compile vision_proxy.py vision_client.py ground.py detect.py bin/glance bin/trace bin/crop
+        run: python -m py_compile vision_proxy.py vision_client.py ground.py detect.py bin/glance bin/trace bin/crop skills/vision-tools/scripts/html_shot.py
       - name: Run core tests
         run: |
           python tests/test_image_rewrite_shapes.py
@@ -35,6 +35,7 @@ jobs:
           python tests/smoke_test_proxy.py
           python tests/smoke_test_egress_failover.py
           python tests/test_vision_client.py
+          python tests/test_html_shot.py
           python tests/test_restore_ui_playbook.py
           python tests/test_trace.py
 
@@ -46,10 +47,11 @@ jobs:
         with:
           python-version: "3.14"
       - name: Compile proxy entry points
-        run: python -m py_compile vision_proxy.py vision_client.py tests/smoke_test_egress_failover.py
+        run: python -m py_compile vision_proxy.py vision_client.py skills/vision-tools/scripts/html_shot.py tests/smoke_test_egress_failover.py
       - name: Run Windows egress smoke test
         run: |
           python tests/smoke_test_egress_failover.py
+          python tests/test_html_shot.py
           python tests/test_trace.py
 
   extensions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Compile Python entry points
-        run: python -m py_compile vision_proxy.py vision_client.py ground.py detect.py bin/glance bin/trace bin/crop skills/vision-tools/scripts/html_shot.py
+        run: >-
+          python -m py_compile vision_proxy.py vision_client.py ground.py detect.py
+          bin/glance bin/trace bin/crop skills/vision-tools/scripts/html_shot.py
       - name: Run core tests
         run: |
           python tests/test_image_rewrite_shapes.py
@@ -47,7 +49,9 @@ jobs:
         with:
           python-version: "3.14"
       - name: Compile proxy entry points
-        run: python -m py_compile vision_proxy.py vision_client.py skills/vision-tools/scripts/html_shot.py tests/smoke_test_egress_failover.py
+        run: >-
+          python -m py_compile vision_proxy.py vision_client.py
+          skills/vision-tools/scripts/html_shot.py tests/smoke_test_egress_failover.py
       - name: Run Windows egress smoke test
         run: |
           python tests/smoke_test_egress_failover.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
           python -m py_compile vision_proxy.py vision_client.py ground.py detect.py
           bin/glance bin/trace bin/crop skills/vision-tools/scripts/html_shot.py
       - name: Run core tests
+        env:
+          HTML_SHOT_REQUIRE_BROWSER: "1"
         run: |
           python tests/test_image_rewrite_shapes.py
           python tests/test_focus_hint.py
@@ -52,7 +54,9 @@ jobs:
         run: >-
           python -m py_compile vision_proxy.py vision_client.py
           skills/vision-tools/scripts/html_shot.py tests/smoke_test_egress_failover.py
-      - name: Run Windows egress smoke test
+      - name: Run Windows tests
+        env:
+          HTML_SHOT_REQUIRE_BROWSER: "1"
         run: |
           python tests/smoke_test_egress_failover.py
           python tests/test_html_shot.py

--- a/skills/vision-tools/SKILL.md
+++ b/skills/vision-tools/SKILL.md
@@ -29,7 +29,7 @@ Pick the tool by the question you are answering:
 | "Cut this box out as its own image file" | `crop` |
 | "OCR this long screenshot / scrolling page / chat history" | `scripts/long_screenshot_ocr.py` |
 | "Extract the icon/logo foreground as transparent PNG — manual region or auto (cropped+scaled screenshots)" | `scripts/extract_fg.py` |
-| "Turn this HTML file into a screenshot" | `scripts/html_shot.py` |
+| "Turn this HTML file into a viewport or full-page screenshot" | `scripts/html_shot.py` |
 | "Which colours dominate a region, and which palette value fits it?" | `scripts/dominant_colors.py` |
 | A relation none of them return — a gap, a distance between two located things | code over the pixels (Pillow) |
 
@@ -56,7 +56,7 @@ work is not hand-coded differently every time:
 - locate / inventory elements → `ground` / `detect`
 - describe / OCR an image → `glance`
 - safely split, OCR, and merge a long screenshot → `scripts/long_screenshot_ocr.py`
-- HTML file to a screenshot → `scripts/html_shot.py`
+- HTML file to a viewport or full-page screenshot → `scripts/html_shot.py`
 
 Hand-written Pillow is only for what none of them return: a relation
 between two things you already located (a gap, a distance), a resize or
@@ -213,15 +213,19 @@ Requires the optional `pillow` (and `numpy` for auto mode).
 python3 scripts/html_shot.py page.html                      # writes page.png, 1280x800
 python3 scripts/html_shot.py page.html --width 1440 --height 900 -o page.png
 python3 scripts/html_shot.py page.html --scale 2            # 2x pixels: small text stays readable
+python3 scripts/html_shot.py page.html --full-page           # complete scroll height, same layout viewport
+python3 scripts/html_shot.py page.html --full-page --max-pixels 40000000
 ```
 
 The visual-alignment loop: write HTML, screenshot it at the reference
 viewport, then compare it with the design. Use `pixel_diff` to locate
 material differences, not to chase a zero-difference score. Rendering
-happens in headless Chrome/Chromium/Edge — no Python dependencies. Only the
-viewport is captured, so pass `--height` for pages taller than the window;
-`--wait-ms N` pauses for fonts, images, or animation before capturing.
-Paths are relative to this skill's own directory.
+happens in headless Chrome/Chromium/Edge — no Python dependencies. The default
+captures only the viewport. Use `--full-page` for the complete document while
+keeping `--width` and `--height` as the layout viewport, so `vh`/`svh` and
+responsive breakpoints do not change. Add `--max-pixels N` when the page height
+is untrusted. `--wait-ms N` pauses for fonts, images, or animation before
+capturing. Paths are relative to this skill's own directory.
 
 ## pixel_diff — where two images differ (local, no vision API)
 

--- a/skills/vision-tools/references/restore-ui.md
+++ b/skills/vision-tools/references/restore-ui.md
@@ -58,7 +58,8 @@ typography, shadows, decorative details, and icon geometry.
 ### Render once, fix once, deliver
 
 1. Render the target viewport with `scripts/html_shot.py` or the project's
-   existing browser setup.
+   existing browser setup. Use `--full-page` only when the reference covers a
+   complete scrolling document; keep the same logical viewport either way.
 2. Inspect the screenshot once. If there is an obvious structural failure such
    as a missing major region, broken wrapping, or a wildly wrong scale, make
    one focused correction and render once more.
@@ -173,7 +174,8 @@ sheet instead of checking them from filenames alone.
 For an existing implementation, start here.
 
 1. Render at the same logical viewport with `scripts/html_shot.py` or the
-   project's browser test setup.
+   project's browser test setup. For a long-page reference, add `--full-page`
+   rather than increasing `--height`, which would change `vh`-based layout.
 2. Compare the render and reference at the same dimensions. Inspect them side
    by side; use `scripts/pixel_diff.py` to locate differences that are hard to
    spot or explain.

--- a/skills/vision-tools/scripts/html_shot.py
+++ b/skills/vision-tools/scripts/html_shot.py
@@ -34,6 +34,10 @@ CHROME_CANDIDATES = (
     "microsoft-edge", "brave-browser",
 )
 
+FULL_PAGE_TIMEOUT_SECONDS = 30.0
+FULL_PAGE_MAX_GROWTH_ROUNDS = 25
+FULL_PAGE_MAX_SCROLL_STEPS = 2000
+
 
 def find_chrome() -> str | None:
     for candidate in CHROME_CANDIDATES:
@@ -59,12 +63,6 @@ def default_output(source: str) -> str:
         stem = Path(urlparse(source).path).stem
         return f"{stem or 'page'}.png"
     return f"{Path(source).stem}.png"
-
-
-def reserve_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
-        listener.bind(("127.0.0.1", 0))
-        return int(listener.getsockname()[1])
 
 
 def read_http_json(port: int, path: str) -> object:
@@ -235,6 +233,25 @@ def wait_for_target(port: int, deadline: float) -> dict:
     raise RuntimeError(f"timed out waiting for Chrome DevTools{detail}")
 
 
+def wait_for_devtools_port(profile: Path, process: subprocess.Popen,
+                           deadline: float) -> int:
+    active_port = profile / "DevToolsActivePort"
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"Chrome exited before DevTools was ready (code {process.returncode})")
+        try:
+            lines = active_port.read_text().splitlines()
+            port = int(lines[0])
+            if 0 < port <= 65535:
+                return port
+        except (OSError, ValueError, IndexError) as error:
+            last_error = error
+        time.sleep(0.05)
+    detail = f": {last_error}" if last_error else ""
+    raise RuntimeError(f"timed out waiting for Chrome DevTools port{detail}")
+
+
 def wait_for_ready(client: DevToolsSocket, deadline: float) -> None:
     while time.monotonic() < deadline:
         if evaluate(client, "document.readyState") == "complete":
@@ -247,27 +264,132 @@ def pause_for_frame(seconds: float) -> None:
     time.sleep(max(0.02, seconds))
 
 
+def build_full_page_command(chrome: str, source: str, profile: Path,
+                            width: int, height: int, scale: int) -> list[str]:
+    command = [
+        chrome, "--headless=new", "--disable-gpu", "--hide-scrollbars",
+        "--no-first-run", "--no-default-browser-check", "--use-mock-keychain",
+        "--blink-settings=imagesLazyLoadingEnabled=false",
+        f"--window-size={width},{height}",
+        "--remote-debugging-port=0",
+        "--remote-debugging-address=127.0.0.1",
+        f"--user-data-dir={profile}",
+    ]
+    if scale != 1:
+        command.append(f"--force-device-scale-factor={scale}")
+    command.append(source)
+    return command
+
+
+def measure_page_height(client: DevToolsSocket) -> int:
+    return int(evaluate(client, """
+        Math.max(document.documentElement.scrollHeight,
+                 document.body ? document.body.scrollHeight : 0)
+    """) or 0)
+
+
+def enforce_pixel_limit(width: int, page_height: int, scale: int,
+                        max_pixels: int | None) -> None:
+    if page_height <= 0:
+        raise RuntimeError("document has no measurable scroll height")
+    output_pixels = width * page_height * scale * scale
+    if max_pixels is not None and output_pixels > max_pixels:
+        raise RuntimeError(
+            f"full-page screenshot would exceed --max-pixels "
+            f"({output_pixels} > {max_pixels})"
+        )
+
+
+def ensure_before_deadline(deadline: float, message: str) -> None:
+    if time.monotonic() >= deadline:
+        raise RuntimeError(message)
+
+
+def settle_full_page(client: DevToolsSocket, width: int, height: int, scale: int,
+                     max_pixels: int | None, deadline: float) -> int:
+    page_height = measure_page_height(client)
+    enforce_pixel_limit(width, page_height, scale, max_pixels)
+    scan_start = 0
+    growth_rounds = 0
+    scroll_steps = 0
+    waited_for_images = False
+
+    while True:
+        ensure_before_deadline(deadline, "timed out while stabilizing the full page")
+        measured_before_sweep = page_height
+        for position in range(scan_start, measured_before_sweep, max(1, height)):
+            scroll_steps += 1
+            if scroll_steps > FULL_PAGE_MAX_SCROLL_STEPS:
+                raise RuntimeError("full page requires too many scroll steps to capture safely")
+            ensure_before_deadline(deadline, "timed out while scrolling the full page")
+            evaluate(client, f"window.scrollTo(0, {position}); true")
+            pause_for_frame(0.12)
+        evaluate(client, f"window.scrollTo(0, {measured_before_sweep}); true")
+        pause_for_frame(0.12)
+
+        measured_after_sweep = measure_page_height(client)
+        enforce_pixel_limit(width, measured_after_sweep, scale, max_pixels)
+        if measured_after_sweep != measured_before_sweep:
+            growth_rounds += 1
+            if growth_rounds > FULL_PAGE_MAX_GROWTH_ROUNDS:
+                raise RuntimeError("page is still changing after repeated full-page sweeps")
+            scan_start = (max(0, measured_before_sweep - height)
+                          if measured_after_sweep > measured_before_sweep else 0)
+            page_height = measured_after_sweep
+            waited_for_images = False
+            continue
+
+        if not waited_for_images:
+            evaluate(client, """
+                Promise.race([
+                  Promise.all(Array.from(document.images)
+                    .filter(image => !image.complete)
+                    .map(image => new Promise(resolve => {
+                      image.addEventListener('load', resolve, {once: true});
+                      image.addEventListener('error', resolve, {once: true});
+                    }))),
+                  new Promise(resolve => setTimeout(resolve, 3000))
+                ]).then(() => true)
+            """)
+            waited_for_images = True
+            ensure_before_deadline(deadline, "timed out while waiting for full-page images")
+            measured_after_images = measure_page_height(client)
+            enforce_pixel_limit(width, measured_after_images, scale, max_pixels)
+            if measured_after_images != page_height:
+                growth_rounds += 1
+                if growth_rounds > FULL_PAGE_MAX_GROWTH_ROUNDS:
+                    raise RuntimeError("page is still changing after image loading")
+                scan_start = (max(0, page_height - height)
+                              if measured_after_images > page_height else 0)
+                page_height = measured_after_images
+                waited_for_images = False
+                continue
+
+        evaluate(client, "window.scrollTo(0, 0); true")
+        pause_for_frame(0.5)
+        final_height = measure_page_height(client)
+        enforce_pixel_limit(width, final_height, scale, max_pixels)
+        if final_height == page_height:
+            return final_height
+        growth_rounds += 1
+        if growth_rounds > FULL_PAGE_MAX_GROWTH_ROUNDS:
+            raise RuntimeError("page is still changing before full-page capture")
+        scan_start = max(0, page_height - height) if final_height > page_height else 0
+        page_height = final_height
+        waited_for_images = False
+
+
 def capture_full_page(chrome: str, source: str, output: Path, width: int, height: int,
                       scale: int, wait_ms: int, max_pixels: int | None) -> int:
-    port = reserve_port()
-    profile = tempfile.mkdtemp(prefix="agent-vision-html-shot-")
+    profile = Path(tempfile.mkdtemp(prefix="agent-vision-html-shot-"))
     process: subprocess.Popen | None = None
     client: DevToolsSocket | None = None
     try:
-        command = [
-            chrome, "--headless=new", "--disable-gpu", "--hide-scrollbars",
-            "--no-first-run", "--no-default-browser-check",
-            "--blink-settings=imagesLazyLoadingEnabled=false",
-            f"--window-size={width},{height}",
-            f"--remote-debugging-port={port}",
-            "--remote-debugging-address=127.0.0.1",
-        ]
-        command.append(f"--user-data-dir={profile}")
-        if scale != 1:
-            command.append(f"--force-device-scale-factor={scale}")
-        command.append(source)
+        command = build_full_page_command(chrome, source, profile, width, height, scale)
         process = subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        target = wait_for_target(port, time.monotonic() + 15.0)
+        startup_deadline = time.monotonic() + 15.0
+        port = wait_for_devtools_port(profile, process, startup_deadline)
+        target = wait_for_target(port, startup_deadline)
         client = DevToolsSocket(str(target["webSocketDebuggerUrl"]))
         client.command("Page.enable")
         client.command("Runtime.enable")
@@ -294,48 +416,10 @@ def capture_full_page(chrome: str, source: str, output: Path, width: int, height
               return true;
             })()
         """)
-        page_height = int(evaluate(client, """
-            Math.max(document.documentElement.scrollHeight,
-                     document.body ? document.body.scrollHeight : 0)
-        """) or 0)
-        for _ in range(2):
-            measured_before_sweep = page_height
-            for position in range(0, page_height, max(1, height)):
-                evaluate(client, f"window.scrollTo(0, {position}); true")
-                pause_for_frame(0.12)
-            evaluate(client, f"window.scrollTo(0, {page_height}); true")
-            pause_for_frame(0.12)
-            page_height = int(evaluate(client, """
-                Math.max(document.documentElement.scrollHeight,
-                         document.body ? document.body.scrollHeight : 0)
-            """) or 0)
-            if page_height <= measured_before_sweep:
-                break
-        evaluate(client, """
-            Promise.race([
-              Promise.all(Array.from(document.images)
-                .filter(image => !image.complete)
-                .map(image => new Promise(resolve => {
-                  image.addEventListener('load', resolve, {once: true});
-                  image.addEventListener('error', resolve, {once: true});
-                }))),
-              new Promise(resolve => setTimeout(resolve, 3000))
-            ]).then(() => true)
-        """)
-        evaluate(client, "window.scrollTo(0, 0); true")
-        pause_for_frame(0.5)
-        page_height = int(evaluate(client, """
-            Math.max(document.documentElement.scrollHeight,
-                     document.body ? document.body.scrollHeight : 0)
-        """) or 0)
-        if page_height <= 0:
-            raise RuntimeError("document has no measurable scroll height")
-        output_pixels = width * page_height * scale * scale
-        if max_pixels is not None and output_pixels > max_pixels:
-            raise RuntimeError(
-                f"full-page screenshot would exceed --max-pixels "
-                f"({output_pixels} > {max_pixels})"
-            )
+        page_height = settle_full_page(
+            client, width, height, scale, max_pixels,
+            time.monotonic() + FULL_PAGE_TIMEOUT_SECONDS,
+        )
         result = client.command("Page.captureScreenshot", {
             "format": "png",
             "fromSurface": True,

--- a/skills/vision-tools/scripts/html_shot.py
+++ b/skills/vision-tools/scripts/html_shot.py
@@ -37,6 +37,7 @@ CHROME_CANDIDATES = (
 FULL_PAGE_TIMEOUT_SECONDS = 30.0
 FULL_PAGE_MAX_GROWTH_ROUNDS = 25
 FULL_PAGE_MAX_SCROLL_STEPS = 2000
+FULL_PAGE_QUIET_MILLISECONDS = 1250
 
 
 def find_chrome() -> str | None:
@@ -264,7 +265,7 @@ def pause_for_frame(seconds: float) -> None:
     time.sleep(max(0.02, seconds))
 
 
-def build_full_page_command(chrome: str, source: str, profile: Path,
+def build_full_page_command(chrome: str, profile: Path,
                             width: int, height: int, scale: int) -> list[str]:
     command = [
         chrome, "--headless=new", "--disable-gpu", "--hide-scrollbars",
@@ -277,7 +278,7 @@ def build_full_page_command(chrome: str, source: str, profile: Path,
     ]
     if scale != 1:
         command.append(f"--force-device-scale-factor={scale}")
-    command.append(source)
+    command.append("about:blank")
     return command
 
 
@@ -305,6 +306,58 @@ def ensure_before_deadline(deadline: float, message: str) -> None:
         raise RuntimeError(message)
 
 
+def wait_for_dom_quiet(client: DevToolsSocket, deadline: float) -> None:
+    remaining_ms = int((deadline - time.monotonic()) * 1000)
+    if remaining_ms <= FULL_PAGE_QUIET_MILLISECONDS:
+        raise RuntimeError("timed out before the page reached a quiet state")
+    max_wait_ms = min(4500, remaining_ms)
+    result = evaluate(client, f"""
+        (() => new Promise(resolve => {{
+          const quietMs = {FULL_PAGE_QUIET_MILLISECONDS};
+          const maxWaitMs = {max_wait_ms};
+          const height = () => Math.max(
+            document.documentElement.scrollHeight,
+            document.body ? document.body.scrollHeight : 0
+          );
+          let lastHeight = height();
+          let quietTimer;
+          let pollTimer;
+          let maxTimer;
+          let observer;
+          let finished = false;
+          const finish = quiet => {{
+            if (finished) return;
+            finished = true;
+            clearTimeout(quietTimer);
+            clearInterval(pollTimer);
+            clearTimeout(maxTimer);
+            observer.disconnect();
+            resolve({{quiet, height: height()}});
+          }};
+          const activity = () => {{
+            lastHeight = height();
+            clearTimeout(quietTimer);
+            quietTimer = setTimeout(() => finish(true), quietMs);
+          }};
+          observer = new MutationObserver(activity);
+          observer.observe(document.documentElement, {{
+            attributes: true,
+            characterData: true,
+            childList: true,
+            subtree: true
+          }});
+          pollTimer = setInterval(() => {{
+            const currentHeight = height();
+            if (currentHeight !== lastHeight) activity();
+          }}, 100);
+          maxTimer = setTimeout(() => finish(false), maxWaitMs);
+          activity();
+        }}))()
+    """)
+    if not isinstance(result, dict) or result.get("quiet") is not True:
+        raise RuntimeError("page did not become quiet before the full-page deadline")
+
+
 def settle_full_page(client: DevToolsSocket, width: int, height: int, scale: int,
                      max_pixels: int | None, deadline: float) -> int:
     page_height = measure_page_height(client)
@@ -326,6 +379,7 @@ def settle_full_page(client: DevToolsSocket, width: int, height: int, scale: int
             pause_for_frame(0.12)
         evaluate(client, f"window.scrollTo(0, {measured_before_sweep}); true")
         pause_for_frame(0.12)
+        wait_for_dom_quiet(client, deadline)
 
         measured_after_sweep = measure_page_height(client)
         enforce_pixel_limit(width, measured_after_sweep, scale, max_pixels)
@@ -366,7 +420,7 @@ def settle_full_page(client: DevToolsSocket, width: int, height: int, scale: int
                 continue
 
         evaluate(client, "window.scrollTo(0, 0); true")
-        pause_for_frame(0.5)
+        wait_for_dom_quiet(client, deadline)
         final_height = measure_page_height(client)
         enforce_pixel_limit(width, final_height, scale, max_pixels)
         if final_height == page_height:
@@ -385,7 +439,7 @@ def capture_full_page(chrome: str, source: str, output: Path, width: int, height
     process: subprocess.Popen | None = None
     client: DevToolsSocket | None = None
     try:
-        command = build_full_page_command(chrome, source, profile, width, height, scale)
+        command = build_full_page_command(chrome, profile, width, height, scale)
         process = subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         startup_deadline = time.monotonic() + 15.0
         port = wait_for_devtools_port(profile, process, startup_deadline)

--- a/skills/vision-tools/scripts/html_shot.py
+++ b/skills/vision-tools/scripts/html_shot.py
@@ -1,24 +1,28 @@
 #!/usr/bin/env python3
-"""html_shot: one-command HTML file (or URL) -> PNG screenshot.
+"""Screenshot an HTML file with headless Chrome/Chromium/Edge.
 
-The render loop for rebuild work: write HTML, screenshot it, pixel_diff it
-against the design image. Rendering happens in a real headless
-Chrome/Chromium/Edge, so the shot shows what a browser actually renders —
-no Python rendering stack, no dependencies beyond a Chrome-family browser
-and the stdlib.
-
-Only the viewport is captured; pass --height (and --scale for HiDPI)
-when the page is taller than the default window. Local HTML files and
-http(s):// URLs both work.
+The default path intentionally remains the small Chrome CLI wrapper used by
+the original upstream tool. ``--full-page`` uses Chrome DevTools Protocol
+instead: the requested viewport remains the layout viewport while the page's
+CSS scroll height is measured and captured in one pass.
 """
 
 import argparse
+import base64
+import hashlib
+import json
 import os
 import shutil
+import socket
+import struct
 import subprocess
-import sys
+import tempfile
+import time
 from pathlib import Path
+from urllib.error import URLError
 from urllib.parse import urlparse
+from urllib.request import urlopen
+
 
 CHROME_CANDIDATES = (
     # macOS
@@ -57,6 +61,304 @@ def default_output(source: str) -> str:
     return f"{Path(source).stem}.png"
 
 
+def reserve_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def read_http_json(port: int, path: str) -> object:
+    with urlopen(f"http://127.0.0.1:{port}{path}", timeout=1.0) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+class DevToolsSocket:
+    """Minimal RFC 6455 client for the Chrome DevTools Protocol."""
+
+    def __init__(self, websocket_url: str):
+        parsed = urlparse(websocket_url)
+        if parsed.scheme != "ws" or parsed.hostname is None or parsed.port is None:
+            raise RuntimeError("invalid DevTools websocket URL")
+        self.socket = socket.create_connection((parsed.hostname, parsed.port), timeout=5.0)
+        self.socket.settimeout(5.0)
+        self.buffer = bytearray()
+        key = base64.b64encode(os.urandom(16)).decode("ascii")
+        request = (
+            f"GET {parsed.path or '/'} HTTP/1.1\r\n"
+            f"Host: {parsed.hostname}:{parsed.port}\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key}\r\n"
+            "Sec-WebSocket-Version: 13\r\n\r\n"
+        ).encode("ascii")
+        self.socket.sendall(request)
+        response = self._read_until(b"\r\n\r\n")
+        if not response.startswith(b"HTTP/1.1 101"):
+            raise RuntimeError("Chrome did not accept the DevTools websocket")
+        expected_accept = base64.b64encode(hashlib.sha1(
+            f"{key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11".encode("ascii")
+        ).digest()).decode("ascii")
+        headers = response.decode("latin-1").split("\r\n")
+        accept = next((line.split(":", 1)[1].strip() for line in headers
+                       if line.lower().startswith("sec-websocket-accept:")), None)
+        if accept != expected_accept:
+            raise RuntimeError("Chrome returned an invalid DevTools websocket handshake")
+        self.next_id = 0
+
+    def _read_until(self, marker: bytes) -> bytes:
+        data = bytearray()
+        while marker not in data:
+            chunk = self.socket.recv(4096)
+            if not chunk:
+                raise RuntimeError("DevTools websocket closed during handshake")
+            data.extend(chunk)
+        boundary = data.index(marker) + len(marker)
+        self.buffer.extend(data[boundary:])
+        return bytes(data[:boundary])
+
+    def _send_frame(self, opcode: int, payload: bytes) -> None:
+        mask = os.urandom(4)
+        masked = bytes(value ^ mask[index % 4] for index, value in enumerate(payload))
+        length = len(masked)
+        if length < 126:
+            header = struct.pack("!BB", 0x80 | opcode, 0x80 | length)
+        elif length < 65536:
+            header = struct.pack("!BBH", 0x80 | opcode, 0x80 | 126, length)
+        else:
+            header = struct.pack("!BBQ", 0x80 | opcode, 0x80 | 127, length)
+        self.socket.sendall(header + mask + masked)
+
+    def _read_frame(self) -> tuple[bool, int, bytes]:
+        header = self._read_exact(2)
+        first, second = header
+        final = (first & 0x80) != 0
+        opcode = first & 0x0F
+        length = second & 0x7F
+        masked = (second & 0x80) != 0
+        if length == 126:
+            length = struct.unpack("!H", self._read_exact(2))[0]
+        elif length == 127:
+            length = struct.unpack("!Q", self._read_exact(8))[0]
+        mask = self._read_exact(4) if masked else None
+        payload = self._read_exact(length)
+        if mask is not None:
+            payload = bytes(value ^ mask[index % 4] for index, value in enumerate(payload))
+        return final, opcode, payload
+
+    def _read_message(self) -> tuple[int, bytes]:
+        fragments: list[bytes] = []
+        message_opcode: int | None = None
+        while True:
+            final, opcode, payload = self._read_frame()
+            if opcode == 0x9:
+                self._send_frame(0xA, payload)
+                continue
+            if opcode == 0x8:
+                raise RuntimeError("DevTools websocket closed")
+            if opcode in (0x1, 0x2):
+                fragments = [payload]
+                message_opcode = opcode
+            elif opcode == 0x0 and message_opcode is not None:
+                fragments.append(payload)
+            else:
+                continue
+            if final and message_opcode is not None:
+                return message_opcode, b"".join(fragments)
+
+    def _read_exact(self, length: int) -> bytes:
+        data = bytearray()
+        if self.buffer:
+            take = min(length, len(self.buffer))
+            data.extend(self.buffer[:take])
+            del self.buffer[:take]
+        while len(data) < length:
+            chunk = self.socket.recv(length - len(data))
+            if not chunk:
+                raise RuntimeError("DevTools websocket closed unexpectedly")
+            data.extend(chunk)
+        return bytes(data)
+
+    def command(self, method: str, params: dict | None = None) -> dict:
+        self.next_id += 1
+        request_id = self.next_id
+        request = {"id": request_id, "method": method}
+        if params is not None:
+            request["params"] = params
+        self._send_frame(0x1, json.dumps(request, separators=(",", ":")).encode("utf-8"))
+        while True:
+            opcode, payload = self._read_message()
+            if opcode != 0x1:
+                continue
+            message = json.loads(payload.decode("utf-8"))
+            if message.get("id") != request_id:
+                continue
+            if "error" in message:
+                raise RuntimeError(f"{method}: {message['error'].get('message', 'CDP command failed')}")
+            return message.get("result", {})
+
+    def close(self) -> None:
+        try:
+            self._send_frame(0x8, b"")
+        except OSError:
+            pass
+        self.socket.close()
+
+
+def evaluate(client: DevToolsSocket, expression: str) -> object:
+    result = client.command("Runtime.evaluate", {
+        "expression": expression,
+        "returnByValue": True,
+        "awaitPromise": True,
+    })
+    if "exceptionDetails" in result:
+        raise RuntimeError(result["exceptionDetails"].get("text", "Runtime.evaluate failed"))
+    remote = result.get("result", {})
+    if remote.get("subtype") == "error":
+        raise RuntimeError(remote.get("description", "Runtime.evaluate failed"))
+    return remote.get("value")
+
+
+def wait_for_target(port: int, deadline: float) -> dict:
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            targets = read_http_json(port, "/json/list")
+            if isinstance(targets, list):
+                for target in targets:
+                    if isinstance(target, dict) and target.get("type") == "page" and target.get("webSocketDebuggerUrl"):
+                        return target
+        except (OSError, URLError, ValueError) as error:
+            last_error = error
+        time.sleep(0.05)
+    detail = f": {last_error}" if last_error else ""
+    raise RuntimeError(f"timed out waiting for Chrome DevTools{detail}")
+
+
+def wait_for_ready(client: DevToolsSocket, deadline: float) -> None:
+    while time.monotonic() < deadline:
+        if evaluate(client, "document.readyState") == "complete":
+            return
+        time.sleep(0.05)
+    raise RuntimeError("timed out waiting for the HTML document")
+
+
+def pause_for_frame(seconds: float) -> None:
+    time.sleep(max(0.02, seconds))
+
+
+def capture_full_page(chrome: str, source: str, output: Path, width: int, height: int,
+                      scale: int, wait_ms: int, max_pixels: int | None) -> int:
+    port = reserve_port()
+    profile = tempfile.mkdtemp(prefix="agent-vision-html-shot-")
+    process: subprocess.Popen | None = None
+    client: DevToolsSocket | None = None
+    try:
+        command = [
+            chrome, "--headless=new", "--disable-gpu", "--hide-scrollbars",
+            "--no-first-run", "--no-default-browser-check",
+            "--blink-settings=imagesLazyLoadingEnabled=false",
+            f"--window-size={width},{height}",
+            f"--remote-debugging-port={port}",
+            "--remote-debugging-address=127.0.0.1",
+        ]
+        command.append(f"--user-data-dir={profile}")
+        if scale != 1:
+            command.append(f"--force-device-scale-factor={scale}")
+        command.append(source)
+        process = subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        target = wait_for_target(port, time.monotonic() + 15.0)
+        client = DevToolsSocket(str(target["webSocketDebuggerUrl"]))
+        client.command("Page.enable")
+        client.command("Runtime.enable")
+        client.command("Emulation.setDeviceMetricsOverride", {
+            "width": width,
+            "height": height,
+            "deviceScaleFactor": scale,
+            "mobile": False,
+            "screenWidth": width,
+            "screenHeight": height,
+        })
+        client.command("Page.navigate", {"url": source})
+        wait_for_ready(client, time.monotonic() + 15.0)
+        if wait_ms > 0:
+            pause_for_frame(wait_ms / 1000.0)
+
+        # Keep the requested viewport fixed. Scrolling, rather than growing
+        # the viewport, wakes IO/reveal handlers without changing vh/svh.
+        evaluate(client, """
+            (() => {
+              document.documentElement.style.scrollBehavior = 'auto';
+              if (document.body) document.body.style.scrollBehavior = 'auto';
+              window.scrollTo(0, 0);
+              return true;
+            })()
+        """)
+        page_height = int(evaluate(client, """
+            Math.max(document.documentElement.scrollHeight,
+                     document.body ? document.body.scrollHeight : 0)
+        """) or 0)
+        for _ in range(2):
+            measured_before_sweep = page_height
+            for position in range(0, page_height, max(1, height)):
+                evaluate(client, f"window.scrollTo(0, {position}); true")
+                pause_for_frame(0.12)
+            evaluate(client, f"window.scrollTo(0, {page_height}); true")
+            pause_for_frame(0.12)
+            page_height = int(evaluate(client, """
+                Math.max(document.documentElement.scrollHeight,
+                         document.body ? document.body.scrollHeight : 0)
+            """) or 0)
+            if page_height <= measured_before_sweep:
+                break
+        evaluate(client, """
+            Promise.race([
+              Promise.all(Array.from(document.images)
+                .filter(image => !image.complete)
+                .map(image => new Promise(resolve => {
+                  image.addEventListener('load', resolve, {once: true});
+                  image.addEventListener('error', resolve, {once: true});
+                }))),
+              new Promise(resolve => setTimeout(resolve, 3000))
+            ]).then(() => true)
+        """)
+        evaluate(client, "window.scrollTo(0, 0); true")
+        pause_for_frame(0.5)
+        page_height = int(evaluate(client, """
+            Math.max(document.documentElement.scrollHeight,
+                     document.body ? document.body.scrollHeight : 0)
+        """) or 0)
+        if page_height <= 0:
+            raise RuntimeError("document has no measurable scroll height")
+        output_pixels = width * page_height * scale * scale
+        if max_pixels is not None and output_pixels > max_pixels:
+            raise RuntimeError(
+                f"full-page screenshot would exceed --max-pixels "
+                f"({output_pixels} > {max_pixels})"
+            )
+        result = client.command("Page.captureScreenshot", {
+            "format": "png",
+            "fromSurface": True,
+            "captureBeyondViewport": True,
+            "clip": {"x": 0, "y": 0, "width": width, "height": page_height, "scale": 1},
+        })
+        data = result.get("data")
+        if not isinstance(data, str):
+            raise RuntimeError("Chrome did not return screenshot data")
+        output.write_bytes(base64.b64decode(data))
+        return page_height
+    finally:
+        if client is not None:
+            client.close()
+        if process is not None and process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=2)
+        shutil.rmtree(profile, ignore_errors=True)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="html_shot",
@@ -69,7 +371,11 @@ def main() -> None:
     parser.add_argument("--scale", type=int, default=1,
                         help="device scale factor: 2 makes the PNG 2x for small text (default: 1)")
     parser.add_argument("--wait-ms", type=int, default=0,
-                        help="virtual time budget in ms before capturing (default: 0, capture immediately)")
+                        help="wait time in ms before capturing (default: 0, capture immediately)")
+    parser.add_argument("--full-page", action="store_true",
+                        help="capture the full CSS scroll height while keeping the requested viewport")
+    parser.add_argument("--max-pixels", type=int,
+                        help="reject full-page captures larger than this many output pixels")
     args = parser.parse_args()
 
     chrome = find_chrome()
@@ -84,6 +390,16 @@ def main() -> None:
         source = path.resolve().as_uri()
 
     output = Path(args.output).expanduser().resolve() if args.output else Path(default_output(source)).resolve()
+    if args.full_page:
+        try:
+            page_height = capture_full_page(
+                chrome, source, output, args.width, args.height,
+                args.scale, args.wait_ms, args.max_pixels,
+            )
+        except Exception as error:
+            parser.exit(1, f"html_shot: full-page capture failed: {error}\n")
+        print(f"wrote {output} ({args.width * args.scale}x{page_height * args.scale}; pageHeight={page_height})")
+        return
 
     command = [
         chrome, "--headless=new", "--disable-gpu", "--hide-scrollbars",

--- a/skills/vision-tools/scripts/html_shot.py
+++ b/skills/vision-tools/scripts/html_shot.py
@@ -323,7 +323,6 @@ def wait_for_dom_quiet(client: DevToolsSocket, deadline: float) -> None:
           let quietTimer;
           let pollTimer;
           let maxTimer;
-          let observer;
           let finished = false;
           const finish = quiet => {{
             if (finished) return;
@@ -331,27 +330,21 @@ def wait_for_dom_quiet(client: DevToolsSocket, deadline: float) -> None:
             clearTimeout(quietTimer);
             clearInterval(pollTimer);
             clearTimeout(maxTimer);
-            observer.disconnect();
             resolve({{quiet, height: height()}});
           }};
-          const activity = () => {{
-            lastHeight = height();
+          const restartQuietTimer = () => {{
             clearTimeout(quietTimer);
             quietTimer = setTimeout(() => finish(true), quietMs);
           }};
-          observer = new MutationObserver(activity);
-          observer.observe(document.documentElement, {{
-            attributes: true,
-            characterData: true,
-            childList: true,
-            subtree: true
-          }});
           pollTimer = setInterval(() => {{
             const currentHeight = height();
-            if (currentHeight !== lastHeight) activity();
+            if (currentHeight !== lastHeight) {{
+              lastHeight = currentHeight;
+              restartQuietTimer();
+            }}
           }}, 100);
           maxTimer = setTimeout(() => finish(false), maxWaitMs);
-          activity();
+          restartQuietTimer();
         }}))()
     """)
     if not isinstance(result, dict) or result.get("quiet") is not True:

--- a/skills/vision-tools/scripts/html_shot.py
+++ b/skills/vision-tools/scripts/html_shot.py
@@ -225,7 +225,8 @@ def wait_for_target(port: int, deadline: float) -> dict:
             targets = read_http_json(port, "/json/list")
             if isinstance(targets, list):
                 for target in targets:
-                    if isinstance(target, dict) and target.get("type") == "page" and target.get("webSocketDebuggerUrl"):
+                    if (isinstance(target, dict) and target.get("type") == "page"
+                            and target.get("webSocketDebuggerUrl")):
                         return target
         except (OSError, URLError, ValueError) as error:
             last_error = error

--- a/tests/test_html_shot.py
+++ b/tests/test_html_shot.py
@@ -58,7 +58,7 @@ def test_cli_screenshot():
                          "<h1>probe</h1></body></html>")
         output = os.path.join(temp_dir, "out.png")
         result = subprocess.run([sys.executable, SCRIPT, html, "--width", "320", "--height", "200",
-                                 "-o", output], text=True, capture_output=True)
+                                 "-o", output], text=True, capture_output=True, timeout=30)
         if result.returncode != 0:
             raise AssertionError(result.stderr)
         assert os.path.isfile(output)
@@ -73,7 +73,7 @@ def test_cli_default_output_in_cwd():
             handle.write("<!doctype html><html><body style=\"margin:0;background:#fff\">"
                          "<p>hi</p></body></html>")
         result = subprocess.run([sys.executable, SCRIPT, html, "--width", "200", "--height", "100"],
-                                cwd=temp_dir, text=True, capture_output=True)
+                                cwd=temp_dir, text=True, capture_output=True, timeout=30)
         if result.returncode != 0:
             raise AssertionError(result.stderr)
         assert os.path.isfile(os.path.join(temp_dir, "probe.png"))
@@ -82,8 +82,59 @@ def test_cli_default_output_in_cwd():
 def test_cli_missing_file_error():
     with tempfile.TemporaryDirectory() as temp_dir:
         result = subprocess.run([sys.executable, SCRIPT, os.path.join(temp_dir, "nope.html")],
-                                text=True, capture_output=True)
+                                text=True, capture_output=True, timeout=30)
         assert result.returncode != 0 and "not found" in result.stderr
+
+
+def test_cli_full_page_keeps_layout_viewport():
+    try:
+        from PIL import Image
+    except ImportError:
+        print("SKIP: Pillow not installed; cannot verify the full-page PNG")
+        return
+    with tempfile.TemporaryDirectory() as temp_dir:
+        html = os.path.join(temp_dir, "full-page.html")
+        with open(html, "w") as handle:
+            handle.write(
+                "<!doctype html><html><head><style>"
+                "html,body{margin:0}"
+                ".viewport{height:100vh;background:#ff0000}"
+                ".tail{height:240px;background:#0000ff}"
+                "</style></head><body>"
+                '<div class="viewport"></div><div class="tail"></div>'
+                "</body></html>"
+            )
+        output = os.path.join(temp_dir, "full-page.png")
+        result = subprocess.run([
+            sys.executable, SCRIPT, html,
+            "--width", "320", "--height", "200", "--scale", "2",
+            "--full-page", "--max-pixels", "1000000", "-o", output,
+        ], text=True, capture_output=True, timeout=30)
+        if result.returncode != 0:
+            raise AssertionError(result.stderr)
+        assert "pageHeight=440" in result.stdout
+        with Image.open(output) as shot:
+            assert shot.size == (640, 880)
+            assert shot.getpixel((20, 398))[:3] == (255, 0, 0)
+            assert shot.getpixel((20, 402))[:3] == (0, 0, 255)
+
+
+def test_cli_full_page_max_pixels_guard():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        html = os.path.join(temp_dir, "too-tall.html")
+        with open(html, "w") as handle:
+            handle.write(
+                "<!doctype html><html><body style=\"margin:0;height:1000px\"></body></html>"
+            )
+        output = os.path.join(temp_dir, "blocked.png")
+        result = subprocess.run([
+            sys.executable, SCRIPT, html,
+            "--width", "320", "--height", "200", "--full-page",
+            "--max-pixels", "1000", "-o", output,
+        ], text=True, capture_output=True, timeout=30)
+        assert result.returncode != 0
+        assert "exceed --max-pixels" in result.stderr
+        assert not os.path.exists(output)
 
 
 def main():
@@ -92,6 +143,8 @@ def main():
     if test_chrome_discovery():
         test_cli_screenshot()
         test_cli_default_output_in_cwd()
+        test_cli_full_page_keeps_layout_viewport()
+        test_cli_full_page_max_pixels_guard()
     print("HTML SHOT TEST PASS")
 
 

--- a/tests/test_html_shot.py
+++ b/tests/test_html_shot.py
@@ -30,6 +30,14 @@ def _load_html_shot():
     return mod
 
 
+def _png_size(path):
+    with open(path, "rb") as handle:
+        header = handle.read(24)
+    assert header[:8] == b"\x89PNG\r\n\x1a\n"
+    assert header[12:16] == b"IHDR"
+    return struct.unpack("!II", header[16:24])
+
+
 def test_chrome_discovery():
     chrome = _load_html_shot().find_chrome()
     if chrome is None:
@@ -108,11 +116,6 @@ def test_websocket_frame_codec():
 
 
 def test_cli_screenshot():
-    try:
-        from PIL import Image
-    except ImportError:
-        print("SKIP: Pillow not installed; cannot verify the PNG")
-        return
     with tempfile.TemporaryDirectory() as temp_dir:
         html = os.path.join(temp_dir, "probe.html")
         with open(html, "w") as handle:
@@ -124,8 +127,7 @@ def test_cli_screenshot():
         if result.returncode != 0:
             raise AssertionError(result.stderr)
         assert os.path.isfile(output)
-        with Image.open(output) as shot:
-            assert shot.size == (320, 200)
+        assert _png_size(output) == (320, 200)
 
 
 def test_cli_default_output_in_cwd():
@@ -149,11 +151,6 @@ def test_cli_missing_file_error():
 
 
 def test_cli_full_page_keeps_layout_viewport():
-    try:
-        from PIL import Image
-    except ImportError:
-        print("SKIP: Pillow not installed; cannot verify the full-page PNG")
-        return
     with tempfile.TemporaryDirectory() as temp_dir:
         html = os.path.join(temp_dir, "full-page.html")
         with open(html, "w") as handle:
@@ -175,10 +172,7 @@ def test_cli_full_page_keeps_layout_viewport():
         if result.returncode != 0:
             raise AssertionError(result.stderr)
         assert "pageHeight=440" in result.stdout
-        with Image.open(output) as shot:
-            assert shot.size == (640, 880)
-            assert shot.getpixel((20, 398))[:3] == (255, 0, 0)
-            assert shot.getpixel((20, 402))[:3] == (0, 0, 255)
+        assert _png_size(output) == (640, 880)
 
 
 def test_cli_full_page_max_pixels_guard():
@@ -203,11 +197,6 @@ def test_cli_full_page_max_pixels_guard():
 
 
 def test_cli_full_page_stabilizes_incremental_growth():
-    try:
-        from PIL import Image
-    except ImportError:
-        print("SKIP: Pillow not installed; cannot verify incremental full-page growth")
-        return
     with tempfile.TemporaryDirectory() as temp_dir:
         html = os.path.join(temp_dir, "incremental.html")
         with open(html, "w") as handle:
@@ -235,9 +224,7 @@ def test_cli_full_page_stabilizes_incremental_growth():
         if result.returncode != 0:
             raise AssertionError(result.stderr)
         assert "pageHeight=2000" in result.stdout
-        with Image.open(output) as shot:
-            assert shot.size == (320, 2000)
-            assert shot.getpixel((20, 1900))[:3] == (0, 0, 255)
+        assert _png_size(output) == (320, 2000)
 
 
 def main():

--- a/tests/test_html_shot.py
+++ b/tests/test_html_shot.py
@@ -8,9 +8,13 @@ skipped, matching the optional-tool convention of the other CLIs.
 import importlib.machinery
 import importlib.util
 import os
+from pathlib import Path
+import socket
+import struct
 import subprocess
 import sys
 import tempfile
+import time
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -43,6 +47,64 @@ def test_default_output_naming():
     assert mod.default_output("/tmp/a/b/page.html") == "page.png"
     assert mod.default_output("https://example.com/foo/bar") == "bar.png"
     assert mod.default_output("https://example.com") == "page.png"
+
+
+def test_full_page_command_isolated():
+    mod = _load_html_shot()
+    profile = Path("disposable-profile")
+    command = mod.build_full_page_command(
+        "chrome", "file:///tmp/page.html", profile,
+        1280, 800, 2,
+    )
+    assert "--use-mock-keychain" in command
+    assert "--remote-debugging-port=0" in command
+    assert f"--user-data-dir={profile}" in command
+    assert "--force-device-scale-factor=2" in command
+    assert not any(arg.startswith("--remote-debugging-port=") and arg != "--remote-debugging-port=0"
+                   for arg in command)
+
+
+def _server_frame(payload, opcode=0x1, final=True):
+    first = (0x80 if final else 0) | opcode
+    length = len(payload)
+    if length < 126:
+        return struct.pack("!BB", first, length) + payload
+    if length < 65536:
+        return struct.pack("!BBH", first, 126, length) + payload
+    return struct.pack("!BBQ", first, 127, length) + payload
+
+
+def test_websocket_frame_codec():
+    mod = _load_html_shot()
+    client_socket, server_socket = socket.socketpair()
+    client = mod.DevToolsSocket.__new__(mod.DevToolsSocket)
+    client.socket = client_socket
+    client.buffer = bytearray()
+    try:
+        payload = b"x" * 130
+        server_socket.sendall(_server_frame(payload))
+        assert client._read_frame() == (True, 0x1, payload)
+
+        server_socket.sendall(
+            _server_frame(b"hel", final=False)
+            + _server_frame(b"ping", opcode=0x9)
+            + _server_frame(b"lo", opcode=0x0)
+        )
+        assert client._read_message() == (0x1, b"hello")
+        pong = server_socket.recv(1024)
+        assert pong[0] == 0x8A and pong[1] & 0x80
+
+        client._send_frame(0x1, b"masked")
+        header = server_socket.recv(2)
+        assert header[0] == 0x81 and header[1] & 0x80
+        length = header[1] & 0x7F
+        mask = server_socket.recv(4)
+        masked = server_socket.recv(length)
+        assert bytes(value ^ mask[index % 4]
+                     for index, value in enumerate(masked)) == b"masked"
+    finally:
+        client_socket.close()
+        server_socket.close()
 
 
 def test_cli_screenshot():
@@ -124,27 +186,71 @@ def test_cli_full_page_max_pixels_guard():
         html = os.path.join(temp_dir, "too-tall.html")
         with open(html, "w") as handle:
             handle.write(
-                "<!doctype html><html><body style=\"margin:0;height:1000px\"></body></html>"
+                "<!doctype html><html><body style=\"margin:0;height:50000px\"></body></html>"
             )
         output = os.path.join(temp_dir, "blocked.png")
+        started = time.monotonic()
         result = subprocess.run([
             sys.executable, SCRIPT, html,
             "--width", "320", "--height", "200", "--full-page",
             "--max-pixels", "1000", "-o", output,
         ], text=True, capture_output=True, timeout=30)
+        elapsed = time.monotonic() - started
         assert result.returncode != 0
         assert "exceed --max-pixels" in result.stderr
         assert not os.path.exists(output)
+        assert elapsed < 5, f"pixel guard rejected too slowly: {elapsed:.2f}s"
+
+
+def test_cli_full_page_stabilizes_incremental_growth():
+    try:
+        from PIL import Image
+    except ImportError:
+        print("SKIP: Pillow not installed; cannot verify incremental full-page growth")
+        return
+    with tempfile.TemporaryDirectory() as temp_dir:
+        html = os.path.join(temp_dir, "incremental.html")
+        with open(html, "w") as handle:
+            handle.write(
+                "<!doctype html><html><head><style>"
+                "html,body{margin:0}.block{height:200px}"
+                ".block:nth-of-type(odd){background:#ff0000}"
+                ".block:nth-of-type(even){background:#0000ff}"
+                "</style></head><body><script>"
+                "let count=0;"
+                "function add(){const node=document.createElement('div');"
+                "node.className='block';document.body.appendChild(node);count++;}"
+                "add();add();"
+                "addEventListener('scroll',()=>{"
+                "if(count<10 && scrollY+innerHeight>=document.documentElement.scrollHeight-1){"
+                "add();add();}});"
+                "</script></body></html>"
+            )
+        output = os.path.join(temp_dir, "incremental.png")
+        result = subprocess.run([
+            sys.executable, SCRIPT, html,
+            "--width", "320", "--height", "200", "--full-page",
+            "--max-pixels", "1000000", "-o", output,
+        ], text=True, capture_output=True, timeout=30)
+        if result.returncode != 0:
+            raise AssertionError(result.stderr)
+        assert "pageHeight=2000" in result.stdout
+        with Image.open(output) as shot:
+            assert shot.size == (320, 2000)
+            assert shot.getpixel((20, 1900))[:3] == (0, 0, 255)
 
 
 def main():
     test_default_output_naming()
+    test_full_page_command_isolated()
+    test_websocket_frame_codec()
     test_cli_missing_file_error()
     if test_chrome_discovery():
         test_cli_screenshot()
         test_cli_default_output_in_cwd()
         test_cli_full_page_keeps_layout_viewport()
         test_cli_full_page_max_pixels_guard()
+        test_cli_full_page_stabilizes_incremental_growth()
     print("HTML SHOT TEST PASS")
 
 

--- a/tests/test_html_shot.py
+++ b/tests/test_html_shot.py
@@ -2,7 +2,8 @@
 """Focused tests for the html_shot case script (HTML file -> PNG).
 
 The CLI half needs a Chrome-family browser; when none is found it is
-skipped, matching the optional-tool convention of the other CLIs.
+skipped unless HTML_SHOT_REQUIRE_BROWSER=1, matching the optional-tool
+convention of the other CLIs while keeping CI coverage mandatory.
 """
 
 import importlib.machinery
@@ -43,6 +44,8 @@ def _png_size(path):
 def test_chrome_discovery():
     chrome = _load_html_shot().find_chrome()
     if chrome is None:
+        if os.environ.get("HTML_SHOT_REQUIRE_BROWSER") == "1":
+            raise AssertionError("HTML_SHOT_REQUIRE_BROWSER=1 but no Chrome-family browser was found")
         print("SKIP: no Chrome-family browser found; CLI run is optional")
         return False
     assert os.path.isfile(chrome) or chrome in (
@@ -243,6 +246,29 @@ def test_cli_full_page_stabilizes_incremental_growth():
         assert _png_size(output) == (320, 2000)
 
 
+def test_cli_full_page_ignores_fixed_height_text_updates():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        html = os.path.join(temp_dir, "clock.html")
+        with open(html, "w") as handle:
+            handle.write(
+                "<!doctype html><html><head><style>"
+                "html,body{margin:0;height:600px}"
+                "</style></head><body><div id='clock'></div><script>"
+                "setInterval(()=>{document.getElementById('clock').textContent=Date.now()},500);"
+                "</script></body></html>"
+            )
+        output = os.path.join(temp_dir, "clock.png")
+        result = subprocess.run([
+            sys.executable, SCRIPT, html,
+            "--width", "320", "--height", "200", "--full-page",
+            "--max-pixels", "1000000", "-o", output,
+        ], text=True, capture_output=True, timeout=30)
+        if result.returncode != 0:
+            raise AssertionError(result.stderr)
+        assert "pageHeight=600" in result.stdout
+        assert _png_size(output) == (320, 600)
+
+
 class CountingHandler(BaseHTTPRequestHandler):
     paths = []
 
@@ -295,6 +321,7 @@ def main():
         test_cli_full_page_keeps_layout_viewport()
         test_cli_full_page_max_pixels_guard()
         test_cli_full_page_stabilizes_incremental_growth()
+        test_cli_full_page_ignores_fixed_height_text_updates()
         test_cli_full_page_loads_url_once()
     print("HTML SHOT TEST PASS")
 

--- a/tests/test_html_shot.py
+++ b/tests/test_html_shot.py
@@ -7,6 +7,7 @@ skipped, matching the optional-tool convention of the other CLIs.
 
 import importlib.machinery
 import importlib.util
+from http.server import BaseHTTPRequestHandler, HTTPServer
 import os
 from pathlib import Path
 import socket
@@ -14,6 +15,7 @@ import struct
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -61,13 +63,13 @@ def test_full_page_command_isolated():
     mod = _load_html_shot()
     profile = Path("disposable-profile")
     command = mod.build_full_page_command(
-        "chrome", "file:///tmp/page.html", profile,
-        1280, 800, 2,
+        "chrome", profile, 1280, 800, 2,
     )
     assert "--use-mock-keychain" in command
     assert "--remote-debugging-port=0" in command
     assert f"--user-data-dir={profile}" in command
     assert "--force-device-scale-factor=2" in command
+    assert command[-1] == "about:blank"
     assert not any(arg.startswith("--remote-debugging-port=") and arg != "--remote-debugging-port=0"
                    for arg in command)
 
@@ -80,6 +82,16 @@ def _server_frame(payload, opcode=0x1, final=True):
     if length < 65536:
         return struct.pack("!BBH", first, 126, length) + payload
     return struct.pack("!BBQ", first, 127, length) + payload
+
+
+def _recv_exact(connection, length):
+    data = bytearray()
+    while len(data) < length:
+        chunk = connection.recv(length - len(data))
+        if not chunk:
+            raise AssertionError("socket closed before the expected test frame arrived")
+        data.extend(chunk)
+    return bytes(data)
 
 
 def test_websocket_frame_codec():
@@ -99,15 +111,15 @@ def test_websocket_frame_codec():
             + _server_frame(b"lo", opcode=0x0)
         )
         assert client._read_message() == (0x1, b"hello")
-        pong = server_socket.recv(1024)
+        pong = _recv_exact(server_socket, 10)
         assert pong[0] == 0x8A and pong[1] & 0x80
 
         client._send_frame(0x1, b"masked")
-        header = server_socket.recv(2)
+        header = _recv_exact(server_socket, 2)
         assert header[0] == 0x81 and header[1] & 0x80
         length = header[1] & 0x7F
-        mask = server_socket.recv(4)
-        masked = server_socket.recv(length)
+        mask = _recv_exact(server_socket, 4)
+        masked = _recv_exact(server_socket, length)
         assert bytes(value ^ mask[index % 4]
                      for index, value in enumerate(masked)) == b"masked"
     finally:
@@ -210,9 +222,13 @@ def test_cli_full_page_stabilizes_incremental_growth():
                 "function add(){const node=document.createElement('div');"
                 "node.className='block';document.body.appendChild(node);count++;}"
                 "add();add();"
+                "let loading=false;"
                 "addEventListener('scroll',()=>{"
-                "if(count<10 && scrollY+innerHeight>=document.documentElement.scrollHeight-1){"
-                "add();add();}});"
+                "if(!loading && count<10 && "
+                "scrollY+innerHeight>=document.documentElement.scrollHeight-1){"
+                "loading=true;setTimeout(()=>{"
+                "for(let i=0;i<4 && count<10;i++)add();loading=false;"
+                "},1000);}});"
                 "</script></body></html>"
             )
         output = os.path.join(temp_dir, "incremental.png")
@@ -227,6 +243,47 @@ def test_cli_full_page_stabilizes_incremental_growth():
         assert _png_size(output) == (320, 2000)
 
 
+class CountingHandler(BaseHTTPRequestHandler):
+    paths = []
+
+    def do_GET(self):
+        CountingHandler.paths.append(self.path)
+        body = (b"<!doctype html><html><body style='margin:0;height:400px'>"
+                b"single navigation</body></html>")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):
+        pass
+
+
+def test_cli_full_page_loads_url_once():
+    server = HTTPServer(("127.0.0.1", 0), CountingHandler)
+    CountingHandler.paths = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = os.path.join(temp_dir, "url.png")
+            source = f"http://127.0.0.1:{server.server_port}/page"
+            result = subprocess.run([
+                sys.executable, SCRIPT, source,
+                "--width", "320", "--height", "200", "--full-page",
+                "--max-pixels", "1000000", "-o", output,
+            ], text=True, capture_output=True, timeout=30)
+            if result.returncode != 0:
+                raise AssertionError(result.stderr)
+            assert _png_size(output) == (320, 400)
+            assert CountingHandler.paths.count("/page") == 1, CountingHandler.paths
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
 def main():
     test_default_output_naming()
     test_full_page_command_isolated()
@@ -238,6 +295,7 @@ def main():
         test_cli_full_page_keeps_layout_viewport()
         test_cli_full_page_max_pixels_guard()
         test_cli_full_page_stabilizes_incremental_growth()
+        test_cli_full_page_loads_url_once()
     print("HTML SHOT TEST PASS")
 
 

--- a/tests/test_vision_client.py
+++ b/tests/test_vision_client.py
@@ -143,6 +143,26 @@ def main():
         assert Handler.last_headers.get("User-Agent") == vision_client.DEFAULT_USER_AGENT
         assert not Handler.last_headers["User-Agent"].startswith("Python-urllib/")
 
+        Handler.calls, Handler.statuses, Handler.bodies, Handler.response_headers = (
+            0,
+            [429],
+            [b'{"error":{"code":"daily_rate_limit_exceeded","message":"Daily limit reached"}}'],
+            [{"Retry-After": "3600"}],
+        )
+        delays = []
+        original_sleep = vision_client.time.sleep
+        vision_client.time.sleep = delays.append
+        try:
+            vision_client.describe_image("data:image/png;base64,AAAA")
+        except vision_client.VisionError as exc:
+            assert "daily_rate_limit_exceeded" in str(exc)
+        else:
+            raise AssertionError("daily quota exhaustion must fail immediately")
+        finally:
+            vision_client.time.sleep = original_sleep
+        assert Handler.calls == 1, "daily quota exhaustion must not be retried"
+        assert delays == []
+
         Handler.calls, Handler.statuses, Handler.bodies = 0, [200], []
         os.environ["VISION_USER_AGENT"] = "custom-vision-client/2.0"
         try:

--- a/tests/test_vision_client.py
+++ b/tests/test_vision_client.py
@@ -163,6 +163,42 @@ def main():
         assert Handler.calls == 1, "daily quota exhaustion must not be retried"
         assert delays == []
 
+        Handler.calls, Handler.statuses, Handler.bodies, Handler.response_headers = (
+            0,
+            [429],
+            [b'{"error":{"code":"global_daily_limit_exceeded","message":"Capacity reached"}}'],
+            [{"Retry-After": "3600"}],
+        )
+        delays = []
+        original_sleep = vision_client.time.sleep
+        vision_client.time.sleep = delays.append
+        try:
+            vision_client.describe_image("data:image/png;base64,AAAA")
+        except vision_client.VisionError as exc:
+            assert "global_daily_limit_exceeded" in str(exc)
+        else:
+            raise AssertionError("global daily quota exhaustion must fail immediately")
+        finally:
+            vision_client.time.sleep = original_sleep
+        assert Handler.calls == 1
+        assert delays == []
+
+        Handler.calls, Handler.statuses, Handler.bodies, Handler.response_headers = (
+            0,
+            [429, 200],
+            [b'{"error":{"code":"rate_limit_exceeded","message":"Retry shortly"}}'],
+            [{"Retry-After": "2"}, {}],
+        )
+        delays = []
+        original_sleep = vision_client.time.sleep
+        vision_client.time.sleep = delays.append
+        try:
+            assert vision_client.describe_image("data:image/png;base64,AAAA") == "fixture answer"
+        finally:
+            vision_client.time.sleep = original_sleep
+        assert Handler.calls == 2, "transient rate limits should remain retryable"
+        assert delays == [2.0]
+
         Handler.calls, Handler.statuses, Handler.bodies = 0, [200], []
         os.environ["VISION_USER_AGENT"] = "custom-vision-client/2.0"
         try:

--- a/vision_client.py
+++ b/vision_client.py
@@ -160,6 +160,29 @@ def _retry_delay(error: urllib.error.HTTPError, attempt: int) -> float:
     return min(2 ** attempt, 4)
 
 
+def _api_error_code(body: bytes) -> str:
+    try:
+        payload = json.loads(body.decode(errors="replace"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return ""
+    code = error.get("code")
+    return code if isinstance(code, str) else ""
+
+
+def _retryable_http_error(status: int, body: bytes) -> bool:
+    if status not in {429, 500, 502, 503, 504, 529}:
+        return False
+    return _api_error_code(body) not in {
+        "daily_rate_limit_exceeded",
+        "global_daily_limit_exceeded",
+    }
+
+
 def describe_image(image_url: str | list[str], prompt: str | None = None, max_tokens: int = 4096,
                    apply_lang: bool = True) -> str:
     """Describe one data/http image URL (str) or several (list) in a single call."""
@@ -253,9 +276,10 @@ def describe_image(image_url: str | list[str], prompt: str | None = None, max_to
                 raise VisionError("Vision API returned an empty description")
             return text
         except urllib.error.HTTPError as exc:
-            body = _redact(exc.read().decode(errors="replace")[:400], api_key)
+            raw_body = exc.read()
+            body = _redact(raw_body.decode(errors="replace")[:400], api_key)
             body = body.replace("\r", " ").replace("\n", " ")
-            if exc.code in {429, 500, 502, 503, 504, 529} and attempt < retries:
+            if _retryable_http_error(exc.code, raw_body) and attempt < retries:
                 print(f"vision: HTTP {exc.code}, retrying ({attempt + 1}/{retries})", file=sys.stderr)
                 time.sleep(_retry_delay(exc, attempt))
                 continue


### PR DESCRIPTION
## Summary

- port the reusable 2026-08-16/17 changes from `Anionex/dsh-vision-toolkit`
- add `html_shot.py --full-page` through Chrome DevTools Protocol while preserving the requested layout viewport and device scale
- stabilize lazy and asynchronously appended content, while tolerating live text/attribute updates that do not change page height
- add an optional `--max-pixels` guard that rejects oversized pages before expensive capture work
- make explicit daily/global daily quota exhaustion fail immediately instead of sleeping through retries
- update the `vision-tools` Skill and UI-restoration playbook for viewport-vs-full-page capture

## DSH update audit

- Already present on `origin/main` via PR #25: Qwen-family `xyxy` coordinate order, explicit `VISION_BOX_ORDER`, incomplete bounding-box JSON rejection, 8192-token grounding output, and idempotent detect prompts.
- Ported here: full-page HTML capture and permanent daily-quota fast failure.
- Not ported: DSH Web settings, plugin auto-update/restart, attachment handling, bundled free-provider defaults, Cloudflare/Groq Worker limits/scheduling, release metadata, and DSH packaging/Skill-sync code. Those are host- or service-specific rather than reusable toolkit behavior.
- Portability adjustment: generic `rate_limit_exceeded` remains retryable because providers commonly use it for transient per-minute limits; only explicit daily/global-daily exhaustion skips retries.

## Files

- `vision_client.py`, `tests/test_vision_client.py`: parse structured API error codes and avoid retrying permanent daily quota errors.
- `skills/vision-tools/scripts/html_shot.py`, `tests/test_html_shot.py`: add full-document capture, fixed layout viewport, scale-aware pixel limits, asynchronous-height stabilization, single URL navigation, Chrome profile cleanup, and real Chrome coverage.
- `.github/workflows/ci.yml`: compile the helper and require real browser execution on Linux and Windows instead of allowing a silent skip.
- `skills/vision-tools/SKILL.md`, `skills/vision-tools/references/restore-ui.md`: document when to use viewport or full-page screenshots.

## Verification

- required `py_compile` gate: passed
- required proxy/rewrite/client suite: passed
- `python3 tests/test_ground.py`: passed, including the Qwen coordinate regression already on the base branch
- `python3 tests/test_detect.py`: passed
- `HTML_SHOT_REQUIRE_BROWSER=1 python3 tests/test_html_shot.py`: passed against real local Chrome
  - fixed viewport: 320x200
  - scale-2 full page: 640x880 PNG from a 320x440 CSS page
  - 1-second delayed incremental growth: complete 320x2000 capture
  - fixed-height page updating text every 500ms: successful 320x600 capture
  - 50,000px oversized page: rejected quickly without an output artifact
  - HTTP `/page` main document: requested exactly once
- remaining Python test scripts: passed; the optional vtracer CLI case skipped because its optional dependency is absent
- `node tests/test_extensions.mjs`: passed
- `git diff --check`: passed
- assets under `assets/`: unchanged

## CI and review

- GitHub Actions run `31986696699`: Python 3.11, Python 3.14, Windows Python 3.14, and extensions all passed.
- Linux and Windows logs both show real `HTML SHOT TEST PASS` execution with `HTML_SHOT_REQUIRE_BROWSER=1`; no browser-discovery skip occurred.
- The hosted review bot was unavailable because its review quota was exhausted, so the required fallback adversarial review loop was used.
- Earlier review findings around delayed growth, duplicate URL navigation, persistent DOM updates, browser-required CI, pixel-limit timing, and socket reliability were fixed and retested.
- A fresh final adversarial review of HEAD `6a9eaf6` reported: **no high-value actionable issues**.

## E2E / acceptance

There is no frontend or admin workflow in this change, so Playwright/browser-use would not exercise a meaningful product path. The substitute end-to-end path launches a real installed Chrome through the affected CLI, loads local HTML and HTTP pages, captures viewport/full-page PNGs, and verifies dimensions, lazy growth, live updates, single navigation, and pixel-limit rejection.

Minimal human acceptance command:

```bash
python3 tests/test_html_shot.py
```

Expected final output: `HTML SHOT TEST PASS`.
