### PR TITLE
fix: decode zstd-compressed Codex request bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,16 @@ jobs:
           python tests/test_trace.py
 
   python-egress-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.14"]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: ${{ matrix.python-version }}
       - name: Compile proxy entry points
         run: >-
           python -m py_compile vision_proxy.py vision_client.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           python tests/test_image_rewrite_shapes.py
           python tests/test_focus_hint.py
           python tests/test_anthropic_rewrite.py
+          python tests/test_request_content_encoding.py
           python tests/smoke_test_proxy.py
           python tests/smoke_test_egress_failover.py
           python tests/test_vision_client.py
@@ -58,6 +59,7 @@ jobs:
         env:
           HTML_SHOT_REQUIRE_BROWSER: "1"
         run: |
+          python tests/test_request_content_encoding.py
           python tests/smoke_test_egress_failover.py
           python tests/test_html_shot.py
           python tests/test_trace.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install fallback decoder test dependency
+        if: matrix.python-version == '3.11'
+        run: python -m pip install zstandard==0.25.0
       - name: Compile Python entry points
         run: >-
           python -m py_compile vision_proxy.py vision_client.py ground.py detect.py

--- a/tests/smoke_test_proxy.py
+++ b/tests/smoke_test_proxy.py
@@ -282,15 +282,19 @@ HTTPServer(('127.0.0.1', 19999), H).serve_forever()
             print("ZSTD PASS: compressed function_call_output image is decoded, rewritten, and forwarded")
 
             unsupported = http.client.HTTPConnection("127.0.0.1", 19102, timeout=5)
-            unsupported.request(
-                "POST", "/responses", body=b"{}",
-                headers={"Content-Type": "application/json", "Content-Encoding": "br"},
-            )
+            unsupported.putrequest("POST", "/responses")
+            unsupported.putheader("Content-Type", "application/json")
+            unsupported.putheader("Content-Encoding", "br")
+            unsupported.putheader("Content-Length", str(module.MAX_REQUEST_BODY_BYTES))
+            unsupported.endheaders()
+            unsupported_started = time.monotonic()
             unsupported_response = unsupported.getresponse()
+            unsupported_elapsed = time.monotonic() - unsupported_started
             unsupported_body = unsupported_response.read()
             unsupported.close()
             assert unsupported_response.status == 415, unsupported_response.status
             assert b"Unsupported Content-Encoding: br" in unsupported_body, unsupported_body
+            assert unsupported_elapsed < 1, unsupported_elapsed
 
             invalid = http.client.HTTPConnection("127.0.0.1", 19102, timeout=5)
             invalid.request(

--- a/tests/smoke_test_proxy.py
+++ b/tests/smoke_test_proxy.py
@@ -11,6 +11,7 @@ that carries Codex identity signals, and checks:
 """
 
 import base64
+import gzip
 import http.client
 import importlib.util
 import json
@@ -18,6 +19,7 @@ import os
 import subprocess
 import sys
 import time
+import zlib
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -203,6 +205,36 @@ HTTPServer(('127.0.0.1', 19999), H).serve_forever()
         assert status == 200 and raw == anth_body.encode(), (status, raw)
         assert next((v for k, v in ups2.items() if k.lower() == "x-api-key"), None) == "existing-anthropic-key"
         print("DIALECT PASS: anthropic text-only bodies pass through byte-for-byte")
+
+        layered_raw = b'{"model":"m","input":"compressed text"}'
+        layered_body = zlib.compress(gzip.compress(layered_raw))
+        layered = http.client.HTTPConnection("127.0.0.1", 19101, timeout=5)
+        layered.putrequest("POST", "/responses")
+        layered.putheader("Content-Type", "application/json")
+        layered.putheader("Content-Encoding", "gzip")
+        layered.putheader("Content-Encoding", "deflate")
+        layered.putheader("Content-Length", str(len(layered_body)))
+        layered.endheaders(layered_body)
+        layered_response = layered.getresponse()
+        layered_response.read()
+        layered.close()
+        layered_headers = json.load(open("/tmp/up_headers.json"))
+        assert layered_response.status == 200, layered_response.status
+        assert open("/tmp/up_body.json", "rb").read() == layered_raw
+        assert not any(k.lower() == "content-encoding" for k in layered_headers)
+        print("LAYERED ENCODING PASS: repeated headers decode in wire order")
+
+        oversized = http.client.HTTPConnection("127.0.0.1", 19101, timeout=5)
+        oversized.putrequest("POST", "/responses")
+        oversized.putheader("Content-Type", "application/json")
+        oversized.putheader("Content-Length", str(module.MAX_REQUEST_BODY_BYTES + 1))
+        oversized.endheaders()
+        oversized_response = oversized.getresponse()
+        oversized_body = oversized_response.read()
+        oversized.close()
+        assert oversized_response.status == 413, oversized_response.status
+        assert b"Request body exceeds" in oversized_body, oversized_body
+        print("REQUEST LIMIT PASS: oversized wire bodies return 413 before reading")
 
         # ---- degraded: image bodies without vision config become a visible note ----
         env2 = {k: v for k, v in os.environ.items() if not k.startswith("VISION_")}

--- a/tests/smoke_test_proxy.py
+++ b/tests/smoke_test_proxy.py
@@ -10,6 +10,7 @@ that carries Codex identity signals, and checks:
   - the response body streams through successfully
 """
 
+import base64
 import http.client
 import importlib.util
 import json
@@ -227,6 +228,49 @@ HTTPServer(('127.0.0.1', 19999), H).serve_forever()
                 resp3.read()
                 conn3.close()
                 assert resp3.status == 200, (path, resp3.status)
+
+            # Codex Desktop compresses larger Responses requests with zstd.
+            # This shape is the image returned by view_image, not a pasted image.
+            zstd_body = base64.b64decode(
+                "KLUv/SCRbQMAQgYVGYCpGgN4agW4pCOzJ1shzES6VBL05YCjqI/RiEa8lFKIYJASaiAc7QFSV9H5QkCTDmXKTA6cc6QmC51ZS49pTu1p8HCenmJfFPKFr6nJ7Hwl5NiLCAA0JVcBtIhiwoWtDNiZKGZjGKuCAg=="
+            )
+            conn_zstd = http.client.HTTPConnection("127.0.0.1", 19102, timeout=5)
+            conn_zstd.request(
+                "POST", "/responses", body=zstd_body,
+                headers={"Content-Type": "application/json", "Content-Encoding": "zstd"},
+            )
+            zstd_response = conn_zstd.getresponse()
+            zstd_response.read()
+            conn_zstd.close()
+            assert zstd_response.status == 200, zstd_response.status
+            zstd_upstream = json.load(open("/tmp/up_body.json"))
+            zstd_headers = json.load(open("/tmp/up_headers.json"))
+            assert "input_image" not in json.dumps(zstd_upstream), zstd_upstream
+            assert not any(k.lower() == "content-encoding" for k in zstd_headers), zstd_headers
+            print("ZSTD PASS: compressed function_call_output image is decoded, rewritten, and forwarded")
+
+            unsupported = http.client.HTTPConnection("127.0.0.1", 19102, timeout=5)
+            unsupported.request(
+                "POST", "/responses", body=b"{}",
+                headers={"Content-Type": "application/json", "Content-Encoding": "br"},
+            )
+            unsupported_response = unsupported.getresponse()
+            unsupported_body = unsupported_response.read()
+            unsupported.close()
+            assert unsupported_response.status == 415, unsupported_response.status
+            assert b"Unsupported Content-Encoding: br" in unsupported_body, unsupported_body
+
+            invalid = http.client.HTTPConnection("127.0.0.1", 19102, timeout=5)
+            invalid.request(
+                "POST", "/responses", body=b"not a zstd frame",
+                headers={"Content-Type": "application/json", "Content-Encoding": "zstd"},
+            )
+            invalid_response = invalid.getresponse()
+            invalid_body = invalid_response.read()
+            invalid.close()
+            assert invalid_response.status == 400, invalid_response.status
+            assert b"Invalid zstd request body" in invalid_body, invalid_body
+            print("ENCODING ERROR PASS: unsupported and invalid bodies return explicit 4xx errors")
             upb3 = json.load(open("/tmp/up_body.json"))
             assert "[vision unavailable:" in json.dumps(upb3, ensure_ascii=False), upb3
             log3 = open("/tmp/ds_proxy_test2.log").read()

--- a/tests/test_request_content_encoding.py
+++ b/tests/test_request_content_encoding.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Focused checks for compressed request-body handling in vision_proxy."""
+
+import base64
+import gzip
+import importlib.util
+import json
+import os
+import sys
+import zlib
+
+
+PROXY = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                     "vision_proxy.py")
+sys.path.insert(0, os.path.dirname(PROXY))
+ZSTD_FIXTURE = base64.b64decode(
+    "KLUv/SCRbQMAQgYVGYCpGgN4agW4pCOzJ1shzES6VBL05YCjqI/RiEa8lFKIYJAS"
+    "aiAc7QFSV9H5QkCTDmXKTA6cc6QmC51ZS49pTu1p8HCenmJfFPKFr6nJ7Hwl5NiL"
+    "CAA0JVcBtIhiwoWtDNiZKGZjGKuCAg=="
+)
+ZSTD_SIZELESS_FIXTURE = base64.b64decode(
+    "KLUv/QAAbQMAQgYVGYCpGgN4agW4pCOzJ1shzES6VBL05YCjqI/RiEa8lFKIYJAS"
+    "aiAc7QFSV9H5QkCTDmXKTA6cc6QmC51ZS49pTu1p8HCenmJfFPKFr6nJ7Hwl5NiL"
+    "CAA0JVcBtIhiwoWtDNiZKGZjGKuCAg=="
+)
+RAW = (b'{"model":"m","input":[{"type":"function_call_output",'
+       b'"call_id":"c1","output":[{"type":"input_image",'
+       b'"image_url":"data:image/png;base64,AAAA"}]}]}')
+
+
+def load_proxy():
+    spec = importlib.util.spec_from_file_location("vision_proxy_content_encoding", PROXY)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main():
+    module = load_proxy()
+    assert module._decode_request_body(ZSTD_FIXTURE, "zstd") == RAW
+    assert module._decode_request_body(ZSTD_SIZELESS_FIXTURE, "zstd") == RAW
+    assert module._decode_request_body(gzip.compress(RAW), "gzip") == RAW
+    assert module._decode_request_body(zlib.compress(RAW), "deflate") == RAW
+
+    forwarded = module.Proxy(1, "http://example", "", False, False)._upstream_headers([
+        ("Content-Encoding", "zstd"), ("Content-Type", "application/json")])
+    assert ("Content-Encoding", "zstd") not in forwarded
+    assert ("Content-Type", "application/json") in forwarded
+
+    try:
+        module._decode_request_body(RAW, "br")
+    except ValueError as exc:
+        assert "Unsupported Content-Encoding: br" in str(exc)
+    else:
+        raise AssertionError("unsupported content encodings must fail explicitly")
+
+    parsed = json.loads(module._decode_request_body(ZSTD_FIXTURE, "zstd"))
+    assert parsed["input"][0]["type"] == "function_call_output"
+    print("REQUEST CONTENT-ENCODING PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_request_content_encoding.py
+++ b/tests/test_request_content_encoding.py
@@ -23,6 +23,10 @@ ZSTD_SIZELESS_FIXTURE = base64.b64decode(
     "aiAc7QFSV9H5QkCTDmXKTA6cc6QmC51ZS49pTu1p8HCenmJfFPKFr6nJ7Hwl5NiL"
     "CAA0JVcBtIhiwoWtDNiZKGZjGKuCAg=="
 )
+ZSTD_CHECKSUM_FIXTURE = base64.b64decode(
+    "KLUv/SQa0QAAeyJtb2RlbCI6Im0iLCJpbnB1dCI6Im9rIn0wlGBP"
+)
+ZSTD_CHECKSUM_RAW = b'{"model":"m","input":"ok"}'
 RAW = (b'{"model":"m","input":[{"type":"function_call_output",'
        b'"call_id":"c1","output":[{"type":"input_image",'
        b'"image_url":"data:image/png;base64,AAAA"}]}]}')
@@ -149,6 +153,30 @@ def main():
         pass
     else:
         raise AssertionError("native zstd candidates must expose every required symbol")
+
+    try:
+        import zstandard
+    except ImportError:
+        pass
+    else:
+        assert module._decompress_zstandard_fallback(
+            ZSTD_CHECKSUM_FIXTURE, zstandard) == ZSTD_CHECKSUM_RAW
+        assert module._decompress_zstandard_fallback(
+            ZSTD_CHECKSUM_FIXTURE + ZSTD_CHECKSUM_FIXTURE,
+            zstandard,
+        ) == ZSTD_CHECKSUM_RAW * 2
+        for truncated in (
+            ZSTD_CHECKSUM_FIXTURE[:-1],
+            ZSTD_CHECKSUM_FIXTURE[:-4],
+            ZSTD_CHECKSUM_FIXTURE + ZSTD_CHECKSUM_FIXTURE[:-1],
+            ZSTD_CHECKSUM_FIXTURE + b"JUNK",
+        ):
+            try:
+                module._decompress_zstandard_fallback(truncated, zstandard)
+            except module._InvalidContentEncoding:
+                pass
+            else:
+                raise AssertionError("third-party zstd fallback accepted a truncated frame")
 
     original_limit = module.MAX_DECODED_BODY_BYTES
     module.MAX_DECODED_BODY_BYTES = len(RAW)

--- a/tests/test_request_content_encoding.py
+++ b/tests/test_request_content_encoding.py
@@ -113,6 +113,28 @@ def main():
     else:
         raise AssertionError("invalid zstd frames must remain client errors")
 
+    try:
+        module._raise_python_zstd_error(
+            RuntimeError("Allocation error : not enough memory"))
+    except module._ContentDecoderError:
+        pass
+    else:
+        raise AssertionError("Python zstd allocation failures must be server errors")
+
+    try:
+        module._raise_python_zstd_error(RuntimeError("Unknown frame descriptor"))
+    except module._InvalidContentEncoding:
+        pass
+    else:
+        raise AssertionError("Python zstd frame errors must remain client errors")
+
+    try:
+        module._configure_zstd_library(object())
+    except AttributeError:
+        pass
+    else:
+        raise AssertionError("native zstd candidates must expose every required symbol")
+
     original_limit = module.MAX_DECODED_BODY_BYTES
     module.MAX_DECODED_BODY_BYTES = len(RAW)
     assert module._decode_request_body(gzip.compress(RAW), "gzip") == RAW

--- a/tests/test_request_content_encoding.py
+++ b/tests/test_request_content_encoding.py
@@ -2,12 +2,14 @@
 """Focused checks for compressed request-body handling in vision_proxy."""
 
 import base64
+import asyncio
 import gzip
 import importlib.util
 import json
 import os
 import sys
 import zlib
+from contextlib import asynccontextmanager
 
 
 PROXY = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
@@ -94,15 +96,18 @@ def main():
     internal_error = type(
         "InternalZstdError", (), {
             "ZSTD_isError": lambda self, result: 1,
-            "ZSTD_getErrorCode": lambda self, result: 64,
-            "ZSTD_getErrorName": lambda self, result: b"allocation failed",
+            "ZSTD_getErrorCode": lambda self, result: self.error_code,
+            "ZSTD_getErrorName": lambda self, result: b"internal decoder error",
         })()
-    try:
-        module._raise_zstd_decode_error(internal_error, 1)
-    except module._ContentDecoderError:
-        pass
-    else:
-        raise AssertionError("runtime decoder allocation failures must be server errors")
+    for code in (60, 64, 104, 105, 106, 107):
+        internal_error.error_code = code
+        try:
+            module._raise_zstd_decode_error(internal_error, 1)
+        except module._ContentDecoderError:
+            pass
+        else:
+            raise AssertionError(
+                f"runtime decoder internal error code {code} must be a server error")
 
     invalid_frame = type(
         "InvalidZstdFrame", (), {
@@ -193,7 +198,100 @@ def main():
 
     parsed = json.loads(module._decode_request_body(ZSTD_FIXTURE, "zstd"))
     assert parsed["input"][0]["type"] == "function_call_output"
+    asyncio.run(_concurrent_compressed_requests_do_not_wait_for_upstream())
+    asyncio.run(_identity_body_read_keeps_original_no_timeout())
     print("REQUEST CONTENT-ENCODING PASS")
+
+
+class _FakeUpstreamResponse:
+    def close(self):
+        pass
+
+
+async def _http_exchange(port, request):
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    writer.write(request)
+    await writer.drain()
+    data = await reader.read()
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except Exception:
+        pass
+    return data
+
+
+@asynccontextmanager
+async def _patched_proxy(module, read_timeout, upstream_delay):
+    proxy = module.Proxy(1, "http://127.0.0.1:9", "", False, False)
+    original_timeout = module.REQUEST_BODY_READ_TIMEOUT
+    original_rewrite = module._rewrite_image_inputs
+    original_open = module.Proxy._open_upstream
+    original_send = module.Proxy._send_response
+
+    async def no_rewrite(parsed):
+        return False
+
+    async def delayed_open(self, method, path, body, headers):
+        if upstream_delay:
+            await asyncio.sleep(upstream_delay)
+        return _FakeUpstreamResponse()
+
+    async def send_ok(self, writer, response):
+        writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+        await writer.drain()
+
+    module.REQUEST_BODY_READ_TIMEOUT = read_timeout
+    module._rewrite_image_inputs = no_rewrite
+    module.Proxy._open_upstream = delayed_open
+    module.Proxy._send_response = send_ok
+    try:
+        server = await asyncio.start_server(proxy.handle, "127.0.0.1", 0)
+        async with server:
+            yield proxy, server.sockets[0].getsockname()[1]
+    finally:
+        module.REQUEST_BODY_READ_TIMEOUT = original_timeout
+        module._rewrite_image_inputs = original_rewrite
+        module.Proxy._open_upstream = original_open
+        module.Proxy._send_response = original_send
+
+
+async def _concurrent_compressed_requests_do_not_wait_for_upstream():
+    module = load_proxy()
+    async with _patched_proxy(module, read_timeout=0.4, upstream_delay=1.0) as (proxy, port):
+        request = (
+            f"POST /responses HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n"
+            "Content-Type: application/json\r\nContent-Encoding: zstd\r\n"
+            f"Content-Length: {len(ZSTD_FIXTURE)}\r\nConnection: close\r\n\r\n"
+        ).encode() + ZSTD_FIXTURE
+        responses = await asyncio.gather(
+            _http_exchange(port, request),
+            _http_exchange(port, request),
+        )
+    for data in responses:
+        assert b"200 OK" in data, data
+        assert b"408" not in data, data
+
+
+async def _identity_body_read_keeps_original_no_timeout():
+    module = load_proxy()
+    async with _patched_proxy(module, read_timeout=0.2, upstream_delay=0.0) as (proxy, port):
+        body = b'{"model":"m","input":"ok"}'
+        head = (
+            f"POST /responses HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n"
+            "Content-Type: application/json\r\n"
+            f"Content-Length: {len(body)}\r\nConnection: close\r\n\r\n"
+        ).encode()
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(head)
+        await writer.drain()
+        await asyncio.sleep(0.3)
+        writer.write(body)
+        await writer.drain()
+        data = await reader.read()
+        writer.close()
+        await writer.wait_closed()
+        assert b"200 OK" in data, data
 
 
 if __name__ == "__main__":

--- a/tests/test_request_content_encoding.py
+++ b/tests/test_request_content_encoding.py
@@ -61,6 +61,32 @@ def main():
     else:
         raise AssertionError("unsupported content encodings must fail explicitly")
 
+    try:
+        module._decode_request_body(RAW, "gzip, gzip, gzip, gzip, gzip")
+    except module._InvalidContentEncoding as exc:
+        assert "Too many Content-Encoding layers" in str(exc)
+    else:
+        raise AssertionError("content encoding layers must be bounded")
+
+    try:
+        module._decode_request_body(zlib.compress(RAW) + b"JUNK", "deflate")
+    except module._InvalidContentEncoding as exc:
+        assert "trailing data" in str(exc)
+    else:
+        raise AssertionError("deflate trailing data must not be discarded")
+
+    original_loader = module._load_zstd_library
+    module._load_zstd_library = lambda: type(
+        "UnavailableZstd", (), {"ZSTD_createDStream": lambda self: 0})()
+    try:
+        module._decompress_zstd_native(bytearray(ZSTD_FIXTURE))
+    except module._ContentDecoderError:
+        pass
+    else:
+        raise AssertionError("decoder initialization failures must be server errors")
+    finally:
+        module._load_zstd_library = original_loader
+
     original_limit = module.MAX_DECODED_BODY_BYTES
     module.MAX_DECODED_BODY_BYTES = len(RAW)
     assert module._decode_request_body(gzip.compress(RAW), "gzip") == RAW

--- a/tests/test_request_content_encoding.py
+++ b/tests/test_request_content_encoding.py
@@ -87,6 +87,32 @@ def main():
     finally:
         module._load_zstd_library = original_loader
 
+    internal_error = type(
+        "InternalZstdError", (), {
+            "ZSTD_isError": lambda self, result: 1,
+            "ZSTD_getErrorCode": lambda self, result: 64,
+            "ZSTD_getErrorName": lambda self, result: b"allocation failed",
+        })()
+    try:
+        module._raise_zstd_decode_error(internal_error, 1)
+    except module._ContentDecoderError:
+        pass
+    else:
+        raise AssertionError("runtime decoder allocation failures must be server errors")
+
+    invalid_frame = type(
+        "InvalidZstdFrame", (), {
+            "ZSTD_isError": lambda self, result: 1,
+            "ZSTD_getErrorCode": lambda self, result: 20,
+            "ZSTD_getErrorName": lambda self, result: b"corrupt frame",
+        })()
+    try:
+        module._raise_zstd_decode_error(invalid_frame, 1)
+    except module._InvalidContentEncoding:
+        pass
+    else:
+        raise AssertionError("invalid zstd frames must remain client errors")
+
     original_limit = module.MAX_DECODED_BODY_BYTES
     module.MAX_DECODED_BODY_BYTES = len(RAW)
     assert module._decode_request_body(gzip.compress(RAW), "gzip") == RAW

--- a/tests/test_request_content_encoding.py
+++ b/tests/test_request_content_encoding.py
@@ -121,6 +121,21 @@ def main():
     else:
         raise AssertionError("Python zstd allocation failures must be server errors")
 
+    for message in (
+        "Operation not authorized at current processing stage",
+        "Context should be init first",
+        "Destination buffer is too small",
+        "Operation on NULL destination buffer",
+        "Operation made no progress over multiple calls, due to output buffer being full",
+        "Operation made no progress over multiple calls, due to input being empty",
+    ):
+        try:
+            module._raise_python_zstd_error(RuntimeError(message))
+        except module._ContentDecoderError:
+            pass
+        else:
+            raise AssertionError(f"Python zstd internal error was misclassified: {message}")
+
     try:
         module._raise_python_zstd_error(RuntimeError("Unknown frame descriptor"))
     except module._InvalidContentEncoding:

--- a/tests/test_request_content_encoding.py
+++ b/tests/test_request_content_encoding.py
@@ -41,10 +41,17 @@ def main():
     assert module._decode_request_body(ZSTD_SIZELESS_FIXTURE, "zstd") == RAW
     assert module._decode_request_body(gzip.compress(RAW), "gzip") == RAW
     assert module._decode_request_body(zlib.compress(RAW), "deflate") == RAW
+    raw_encoder = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+    raw_deflate = raw_encoder.compress(RAW) + raw_encoder.flush()
+    assert module._decode_request_body(raw_deflate, "deflate") == RAW
+    layered = zlib.compress(gzip.compress(RAW))
+    assert module._decode_request_body(layered, "gzip, deflate") == RAW
 
-    forwarded = module.Proxy(1, "http://example", "", False, False)._upstream_headers([
-        ("Content-Encoding", "zstd"), ("Content-Type", "application/json")])
-    assert ("Content-Encoding", "zstd") not in forwarded
+    incoming = [("Content-Encoding", "gzip"), ("Content-Encoding", "deflate"),
+                ("Content-Type", "application/json")]
+    assert module._header_values(incoming, "content-encoding") == "gzip, deflate"
+    forwarded = module.Proxy(1, "http://example", "", False, False)._upstream_headers(incoming)
+    assert not any(key.lower() == "content-encoding" for key, _ in forwarded)
     assert ("Content-Type", "application/json") in forwarded
 
     try:
@@ -53,6 +60,19 @@ def main():
         assert "Unsupported Content-Encoding: br" in str(exc)
     else:
         raise AssertionError("unsupported content encodings must fail explicitly")
+
+    original_limit = module.MAX_DECODED_BODY_BYTES
+    module.MAX_DECODED_BODY_BYTES = len(RAW)
+    assert module._decode_request_body(gzip.compress(RAW), "gzip") == RAW
+    module.MAX_DECODED_BODY_BYTES = len(RAW) - 1
+    try:
+        module._decode_request_body(gzip.compress(RAW), "gzip")
+    except module._RequestBodyTooLarge:
+        pass
+    else:
+        raise AssertionError("decoded request bodies must enforce the size limit")
+    finally:
+        module.MAX_DECODED_BODY_BYTES = original_limit
 
     parsed = json.loads(module._decode_request_body(ZSTD_FIXTURE, "zstd"))
     assert parsed["input"][0]["type"] == "function_call_output"

--- a/vision_proxy.py
+++ b/vision_proxy.py
@@ -89,6 +89,30 @@ _ZSTD_LIBRARY = None
 _ZSTD_LIBRARY_LOCK = threading.Lock()
 
 
+def _configure_zstd_library(library):
+    library.ZSTD_createDStream.argtypes = []
+    library.ZSTD_createDStream.restype = ctypes.c_void_p
+    library.ZSTD_freeDStream.argtypes = [ctypes.c_void_p]
+    library.ZSTD_freeDStream.restype = ctypes.c_size_t
+    library.ZSTD_initDStream.argtypes = [ctypes.c_void_p]
+    library.ZSTD_initDStream.restype = ctypes.c_size_t
+    library.ZSTD_DStreamOutSize.argtypes = []
+    library.ZSTD_DStreamOutSize.restype = ctypes.c_size_t
+    library.ZSTD_decompressStream.argtypes = [ctypes.c_void_p,
+                                               ctypes.POINTER(_ZstdOutBuffer),
+                                               ctypes.POINTER(_ZstdInBuffer)]
+    library.ZSTD_decompressStream.restype = ctypes.c_size_t
+    library.ZSTD_DCtx_setParameter.argtypes = [ctypes.c_void_p, ctypes.c_int,
+                                                ctypes.c_int]
+    library.ZSTD_DCtx_setParameter.restype = ctypes.c_size_t
+    library.ZSTD_isError.argtypes = [ctypes.c_size_t]
+    library.ZSTD_isError.restype = ctypes.c_uint
+    library.ZSTD_getErrorCode.argtypes = [ctypes.c_size_t]
+    library.ZSTD_getErrorCode.restype = ctypes.c_uint
+    library.ZSTD_getErrorName.argtypes = [ctypes.c_size_t]
+    library.ZSTD_getErrorName.restype = ctypes.c_char_p
+
+
 def _load_zstd_library():
     global _ZSTD_LIBRARY
     if _ZSTD_LIBRARY is not None:
@@ -117,34 +141,15 @@ def _load_zstd_library():
                 continue
             try:
                 library = ctypes.CDLL(candidate)
+                _configure_zstd_library(library)
                 break
-            except OSError:
+            except (OSError, AttributeError):
+                library = None
                 continue
         if library is None:
             raise _UnsupportedContentEncoding(
                 "Unsupported Content-Encoding: zstd (no decoder is available)")
 
-        library.ZSTD_createDStream.argtypes = []
-        library.ZSTD_createDStream.restype = ctypes.c_void_p
-        library.ZSTD_freeDStream.argtypes = [ctypes.c_void_p]
-        library.ZSTD_freeDStream.restype = ctypes.c_size_t
-        library.ZSTD_initDStream.argtypes = [ctypes.c_void_p]
-        library.ZSTD_initDStream.restype = ctypes.c_size_t
-        library.ZSTD_DStreamOutSize.argtypes = []
-        library.ZSTD_DStreamOutSize.restype = ctypes.c_size_t
-        library.ZSTD_decompressStream.argtypes = [ctypes.c_void_p,
-                                                   ctypes.POINTER(_ZstdOutBuffer),
-                                                   ctypes.POINTER(_ZstdInBuffer)]
-        library.ZSTD_decompressStream.restype = ctypes.c_size_t
-        library.ZSTD_DCtx_setParameter.argtypes = [ctypes.c_void_p, ctypes.c_int,
-                                                    ctypes.c_int]
-        library.ZSTD_DCtx_setParameter.restype = ctypes.c_size_t
-        library.ZSTD_isError.argtypes = [ctypes.c_size_t]
-        library.ZSTD_isError.restype = ctypes.c_uint
-        library.ZSTD_getErrorCode.argtypes = [ctypes.c_size_t]
-        library.ZSTD_getErrorCode.restype = ctypes.c_uint
-        library.ZSTD_getErrorName.argtypes = [ctypes.c_size_t]
-        library.ZSTD_getErrorName.restype = ctypes.c_char_p
         _ZSTD_LIBRARY = library
         return library
 
@@ -163,6 +168,17 @@ def _raise_zstd_decode_error(library, result):
     if library.ZSTD_getErrorCode(result) in ZSTD_INTERNAL_ERROR_CODES:
         raise _ContentDecoderError(f"zstd decoder failed: {error}")
     raise _InvalidContentEncoding(f"Invalid zstd request body: {error}")
+
+
+def _raise_python_zstd_error(exc):
+    message = str(exc)
+    internal_markers = (
+        "allocation", "not enough memory", "workspace", "internal error",
+        "stage wrong", "init missing",
+    )
+    if any(marker in message.lower() for marker in internal_markers):
+        raise _ContentDecoderError(f"zstd decoder failed: {message}") from exc
+    raise _InvalidContentEncoding(f"Invalid zstd request body: {message}") from exc
 
 
 def _append_decoded(output, chunk):
@@ -233,8 +249,10 @@ def _decompress_zstd(body):
             options = {zstd.DecompressionParameter.window_log_max: ZSTD_WINDOW_LOG_MAX}
             with zstd.open(io.BytesIO(body), "rb", options=options) as reader:
                 return _read_decoded_stream(reader)
+        except MemoryError as exc:
+            raise _ContentDecoderError("zstd decoder ran out of memory") from exc
         except zstd.ZstdError as exc:
-            raise _InvalidContentEncoding(f"Invalid zstd request body: {exc}") from exc
+            _raise_python_zstd_error(exc)
 
     try:
         return _decompress_zstd_native(body)
@@ -250,8 +268,10 @@ def _decompress_zstd(body):
                 max_window_size=1 << ZSTD_WINDOW_LOG_MAX)
             with decompressor.stream_reader(io.BytesIO(body)) as reader:
                 return _read_decoded_stream(reader)
+        except MemoryError as exc:
+            raise _ContentDecoderError("zstd decoder ran out of memory") from exc
         except zstandard.ZstdError as exc:
-            raise _InvalidContentEncoding(f"Invalid zstd request body: {exc}") from exc
+            _raise_python_zstd_error(exc)
 
 
 def _decompress_deflate(body, wbits):

--- a/vision_proxy.py
+++ b/vision_proxy.py
@@ -41,7 +41,8 @@ ZSTD_WINDOW_LOG_MAX = 26
 MAX_CONTENT_CODINGS = 4
 REQUEST_BODY_READ_TIMEOUT = 30.0
 SUPPORTED_CONTENT_CODINGS = {"identity", "gzip", "x-gzip", "deflate", "zstd"}
-ZSTD_INTERNAL_ERROR_CODES = {60, 62, 64, 66, 70, 74, 80, 82}
+# Stable libzstd internal-error codes plus unstable buffer/sequence misuse codes.
+ZSTD_INTERNAL_ERROR_CODES = {60, 62, 64, 66, 70, 74, 80, 82, 104, 105, 106, 107}
 
 
 def _header_value(headers, name):
@@ -207,16 +208,22 @@ def _decompress_zstandard_fallback(body, zstandard):
                         "Invalid zstd request body: truncated frame")
                 decoded = decoder.decompress(chunk)
                 _append_decoded(output, decoded)
-                if decoder.unconsumed_tail:
-                    if decoder.unconsumed_tail == chunk and not decoded:
+                unconsumed = decoder.unconsumed_tail
+                if unconsumed:
+                    if bytes(unconsumed) == bytes(chunk) and not decoded:
                         raise _InvalidContentEncoding(
                             "Invalid zstd request body: decoder made no progress")
-                    pending = decoder.unconsumed_tail + pending
-            pending = decoder.unused_data + pending
+                    pending = unconsumed
+            pending += decoder.unused_data
+        except (_UnsupportedContentEncoding, _InvalidContentEncoding,
+                _RequestBodyTooLarge, _ContentDecoderError):
+            raise
         except MemoryError as exc:
             raise _ContentDecoderError("zstd decoder ran out of memory") from exc
         except zstandard.ZstdError as exc:
             _raise_python_zstd_error(exc)
+        except Exception as exc:
+            raise _ContentDecoderError(f"zstd fallback decoder failed: {exc!r}") from exc
     return output
 
 
@@ -1279,39 +1286,48 @@ class Proxy:
             except _InvalidContentEncoding as exc:
                 await self._send_error(writer, 400, str(exc))
                 return
-            body_deadline = asyncio.get_running_loop().time() + REQUEST_BODY_READ_TIMEOUT
-            if any(coding != "identity" for coding in content_codings):
+            compressed_body = any(coding != "identity" for coding in content_codings)
+            body_deadline = None
+            if compressed_body:
+                body_deadline = asyncio.get_running_loop().time() + REQUEST_BODY_READ_TIMEOUT
                 try:
                     await asyncio.wait_for(
                         self._decode_semaphore.acquire(),
                         timeout=max(0, body_deadline - asyncio.get_running_loop().time()),
                     )
                 except TimeoutError:
-                    await self._send_error(writer, 408, "request body read timed out")
+                    await self._send_error(
+                        writer, 408, "request timed out waiting for another request to decode")
                     return
                 decode_slot_acquired = True
             body = bytearray(body_start)
             while len(body) < content_length:
-                remaining = body_deadline - asyncio.get_running_loop().time()
-                if remaining <= 0:
-                    await self._send_error(writer, 408, "request body read timed out")
-                    return
-                try:
-                    chunk = await asyncio.wait_for(
-                        reader.read(min(65536, content_length - len(body))),
-                        timeout=remaining,
-                    )
-                except TimeoutError:
-                    await self._send_error(writer, 408, "request body read timed out")
-                    return
+                if body_deadline is None:
+                    chunk = await reader.read(min(65536, content_length - len(body)))
+                else:
+                    remaining = body_deadline - asyncio.get_running_loop().time()
+                    if remaining <= 0:
+                        await self._send_error(writer, 408, "request body read timed out")
+                        return
+                    try:
+                        chunk = await asyncio.wait_for(
+                            reader.read(min(65536, content_length - len(body))),
+                            timeout=remaining,
+                        )
+                    except TimeoutError:
+                        await self._send_error(writer, 408, "request body read timed out")
+                        return
                 if not chunk:
                     break
                 body.extend(chunk)
             if len(body) < content_length:
                 await self._send_error(writer, 400, "incomplete request body")
                 return
+            # The decode slot guards only CPU/memory-bound decompression.
+            # Holding it through image rewrite or upstream egress would
+            # serialize concurrent compressed requests for up to minutes.
             try:
-                if content_encoding:
+                if compressed_body:
                     body = await asyncio.to_thread(
                         _decode_request_body, body, content_encoding)
                     if not isinstance(body, bytearray):
@@ -1332,6 +1348,10 @@ class Proxy:
                 _log(f"[vision-proxy] request decoder failed: {exc}")
                 await self._send_error(writer, 500, "Request decoder failed")
                 return
+            finally:
+                if decode_slot_acquired:
+                    self._decode_semaphore.release()
+                    decode_slot_acquired = False
             parsed = None
             if body:
                 try:
@@ -1349,9 +1369,6 @@ class Proxy:
             response = await self._open_upstream(method, path, bytes(body), self._upstream_headers(incoming_headers))
             parsed = None
             body = None
-            if decode_slot_acquired:
-                self._decode_semaphore.release()
-                decode_slot_acquired = False
             response_started = True
             await self._send_response(writer, response)
         except VisionError as exc:

--- a/vision_proxy.py
+++ b/vision_proxy.py
@@ -39,6 +39,8 @@ DECODE_CHUNK_BYTES = 64 * 1024
 ZSTD_WINDOW_LOG_MAX = 26
 MAX_CONTENT_CODINGS = 4
 REQUEST_BODY_READ_TIMEOUT = 30.0
+SUPPORTED_CONTENT_CODINGS = {"identity", "gzip", "x-gzip", "deflate", "zstd"}
+ZSTD_INTERNAL_ERROR_CODES = {60, 62, 64, 66, 70, 74, 80, 82}
 
 
 def _header_value(headers, name):
@@ -139,6 +141,8 @@ def _load_zstd_library():
         library.ZSTD_DCtx_setParameter.restype = ctypes.c_size_t
         library.ZSTD_isError.argtypes = [ctypes.c_size_t]
         library.ZSTD_isError.restype = ctypes.c_uint
+        library.ZSTD_getErrorCode.argtypes = [ctypes.c_size_t]
+        library.ZSTD_getErrorCode.restype = ctypes.c_uint
         library.ZSTD_getErrorName.argtypes = [ctypes.c_size_t]
         library.ZSTD_getErrorName.restype = ctypes.c_char_p
         _ZSTD_LIBRARY = library
@@ -150,6 +154,15 @@ def _zstd_error(library, result):
         return None
     name = library.ZSTD_getErrorName(result)
     return name.decode("utf-8", errors="replace") if name else "unknown zstd error"
+
+
+def _raise_zstd_decode_error(library, result):
+    error = _zstd_error(library, result)
+    if not error:
+        return
+    if library.ZSTD_getErrorCode(result) in ZSTD_INTERNAL_ERROR_CODES:
+        raise _ContentDecoderError(f"zstd decoder failed: {error}")
+    raise _InvalidContentEncoding(f"Invalid zstd request body: {error}")
 
 
 def _append_decoded(output, chunk):
@@ -198,9 +211,7 @@ def _decompress_zstd_native(body):
             previous_input_pos = input_buffer.pos
             result = library.ZSTD_decompressStream(
                 stream, ctypes.byref(output_buffer), ctypes.byref(input_buffer))
-            error = _zstd_error(library, result)
-            if error:
-                raise _InvalidContentEncoding(f"Invalid zstd request body: {error}")
+            _raise_zstd_decode_error(library, result)
             if output_buffer.pos:
                 _append_decoded(output_bytes, output.raw[:output_buffer.pos])
             if result == 0 and input_buffer.pos == input_buffer.size:
@@ -273,6 +284,11 @@ def _content_codings(content_encoding):
     if len(codings) > MAX_CONTENT_CODINGS:
         raise _InvalidContentEncoding(
             f"Too many Content-Encoding layers (maximum {MAX_CONTENT_CODINGS})")
+    unsupported = next((coding for coding in codings
+                        if coding not in SUPPORTED_CONTENT_CODINGS), None)
+    if unsupported:
+        raise _UnsupportedContentEncoding(
+            f"Unsupported Content-Encoding: {unsupported}")
     return codings
 
 
@@ -1207,15 +1223,25 @@ class Proxy:
                 return
             content_encoding = _header_values(incoming_headers, "content-encoding")
             try:
-                _content_codings(content_encoding)
+                content_codings = _content_codings(content_encoding)
+            except _UnsupportedContentEncoding as exc:
+                await self._send_error(writer, 415, str(exc))
+                return
             except _InvalidContentEncoding as exc:
                 await self._send_error(writer, 400, str(exc))
                 return
-            if content_encoding:
-                await self._decode_semaphore.acquire()
+            body_deadline = asyncio.get_running_loop().time() + REQUEST_BODY_READ_TIMEOUT
+            if any(coding != "identity" for coding in content_codings):
+                try:
+                    await asyncio.wait_for(
+                        self._decode_semaphore.acquire(),
+                        timeout=max(0, body_deadline - asyncio.get_running_loop().time()),
+                    )
+                except TimeoutError:
+                    await self._send_error(writer, 408, "request body read timed out")
+                    return
                 decode_slot_acquired = True
             body = bytearray(body_start)
-            body_deadline = asyncio.get_running_loop().time() + REQUEST_BODY_READ_TIMEOUT
             while len(body) < content_length:
                 remaining = body_deadline - asyncio.get_running_loop().time()
                 if remaining <= 0:
@@ -1257,9 +1283,6 @@ class Proxy:
                 _log(f"[vision-proxy] request decoder failed: {exc}")
                 await self._send_error(writer, 500, "Request decoder failed")
                 return
-            if decode_slot_acquired:
-                self._decode_semaphore.release()
-                decode_slot_acquired = False
             parsed = None
             if body:
                 try:
@@ -1275,6 +1298,11 @@ class Proxy:
             model = parsed.get("model") if isinstance(parsed, dict) else None
             _log(f"[vision-proxy] request {method} {path} model={model} body_bytes={len(body)}")
             response = await self._open_upstream(method, path, bytes(body), self._upstream_headers(incoming_headers))
+            parsed = None
+            body = None
+            if decode_slot_acquired:
+                self._decode_semaphore.release()
+                decode_slot_acquired = False
             response_started = True
             await self._send_response(writer, response)
         except VisionError as exc:

--- a/vision_proxy.py
+++ b/vision_proxy.py
@@ -36,6 +36,7 @@ EGRESS_READ_TIMEOUT = 600.0
 MAX_REQUEST_BODY_BYTES = 64 * 1024 * 1024
 MAX_DECODED_BODY_BYTES = 64 * 1024 * 1024
 DECODE_CHUNK_BYTES = 64 * 1024
+ZSTD_FALLBACK_INPUT_CHUNK_BYTES = 256
 ZSTD_WINDOW_LOG_MAX = 26
 MAX_CONTENT_CODINGS = 4
 REQUEST_BODY_READ_TIMEOUT = 30.0
@@ -183,6 +184,42 @@ def _raise_python_zstd_error(exc):
     raise _InvalidContentEncoding(f"Invalid zstd request body: {message}") from exc
 
 
+def _decompress_zstandard_fallback(body, zstandard):
+    if not body:
+        raise _InvalidContentEncoding("Invalid zstd request body: empty frame")
+    output = bytearray()
+    offset = 0
+    pending = b""
+    while offset < len(body) or pending:
+        try:
+            decoder = zstandard.ZstdDecompressor(
+                max_window_size=1 << ZSTD_WINDOW_LOG_MAX).decompressobj()
+            while not decoder.eof:
+                if pending:
+                    chunk = pending
+                    pending = b""
+                elif offset < len(body):
+                    end = min(len(body), offset + ZSTD_FALLBACK_INPUT_CHUNK_BYTES)
+                    chunk = body[offset:end]
+                    offset = end
+                else:
+                    raise _InvalidContentEncoding(
+                        "Invalid zstd request body: truncated frame")
+                decoded = decoder.decompress(chunk)
+                _append_decoded(output, decoded)
+                if decoder.unconsumed_tail:
+                    if decoder.unconsumed_tail == chunk and not decoded:
+                        raise _InvalidContentEncoding(
+                            "Invalid zstd request body: decoder made no progress")
+                    pending = decoder.unconsumed_tail + pending
+            pending = decoder.unused_data + pending
+        except MemoryError as exc:
+            raise _ContentDecoderError("zstd decoder ran out of memory") from exc
+        except zstandard.ZstdError as exc:
+            _raise_python_zstd_error(exc)
+    return output
+
+
 def _append_decoded(output, chunk):
     if len(output) + len(chunk) > MAX_DECODED_BODY_BYTES:
         raise _RequestBodyTooLarge(
@@ -256,7 +293,14 @@ def _decompress_zstd(body):
         except zstd.ZstdError as exc:
             _raise_python_zstd_error(exc)
 
-    return _decompress_zstd_native(body)
+    try:
+        return _decompress_zstd_native(body)
+    except _UnsupportedContentEncoding as native_error:
+        try:
+            import zstandard
+        except ImportError:
+            raise native_error
+        return _decompress_zstandard_fallback(body, zstandard)
 
 
 def _decompress_deflate(body, wbits):

--- a/vision_proxy.py
+++ b/vision_proxy.py
@@ -37,6 +37,8 @@ MAX_REQUEST_BODY_BYTES = 64 * 1024 * 1024
 MAX_DECODED_BODY_BYTES = 64 * 1024 * 1024
 DECODE_CHUNK_BYTES = 64 * 1024
 ZSTD_WINDOW_LOG_MAX = 26
+MAX_CONTENT_CODINGS = 4
+REQUEST_BODY_READ_TIMEOUT = 30.0
 
 
 def _header_value(headers, name):
@@ -62,6 +64,10 @@ class _InvalidContentEncoding(ValueError):
 
 
 class _RequestBodyTooLarge(ValueError):
+    pass
+
+
+class _ContentDecoderError(RuntimeError):
     pass
 
 
@@ -167,20 +173,23 @@ def _decompress_zstd_native(body):
     library = _load_zstd_library()
     stream = library.ZSTD_createDStream()
     if not stream:
-        raise _InvalidContentEncoding("Invalid zstd request body: cannot create decoder")
+        raise _ContentDecoderError("cannot create zstd decoder")
 
-    source = ctypes.create_string_buffer(body)
+    if isinstance(body, bytearray):
+        source = (ctypes.c_char * len(body)).from_buffer(body)
+    else:
+        source = ctypes.create_string_buffer(body)
     input_buffer = _ZstdInBuffer(ctypes.cast(source, ctypes.c_void_p), len(body), 0)
     output_bytes = bytearray()
     try:
         result = library.ZSTD_DCtx_setParameter(stream, 100, ZSTD_WINDOW_LOG_MAX)
         error = _zstd_error(library, result)
         if error:
-            raise _InvalidContentEncoding(f"Invalid zstd request body: {error}")
+            raise _ContentDecoderError(f"cannot configure zstd decoder: {error}")
         result = library.ZSTD_initDStream(stream)
         error = _zstd_error(library, result)
         if error:
-            raise _InvalidContentEncoding(f"Invalid zstd request body: {error}")
+            raise _ContentDecoderError(f"cannot initialize zstd decoder: {error}")
 
         output_size = library.ZSTD_DStreamOutSize()
         while input_buffer.pos < input_buffer.size or result != 0:
@@ -248,6 +257,9 @@ def _decompress_deflate(body, wbits):
             raise _InvalidContentEncoding("Invalid deflate request body: decoder made no progress")
     if not decoder.eof:
         raise _InvalidContentEncoding("Invalid deflate request body: truncated stream")
+    if decoder.unused_data:
+        raise _InvalidContentEncoding(
+            "Invalid deflate request body: trailing data after stream")
     _append_decoded(
         output,
         decoder.flush(min(DECODE_CHUNK_BYTES, MAX_DECODED_BODY_BYTES - len(output) + 1)),
@@ -255,9 +267,17 @@ def _decompress_deflate(body, wbits):
     return output
 
 
-def _decode_request_body(body, content_encoding):
+def _content_codings(content_encoding):
     codings = [coding.strip().lower() for coding in (content_encoding or "").split(",")
                if coding.strip()]
+    if len(codings) > MAX_CONTENT_CODINGS:
+        raise _InvalidContentEncoding(
+            f"Too many Content-Encoding layers (maximum {MAX_CONTENT_CODINGS})")
+    return codings
+
+
+def _decode_request_body(body, content_encoding):
+    codings = _content_codings(content_encoding)
     for coding in reversed(codings):
         try:
             if coding == "identity":
@@ -1148,7 +1168,7 @@ class Proxy:
             self._routes.append(_EgressRoute("proxy", upstream_proxy))
         if proxy_first and len(self._routes) > 1:
             self._routes.reverse()
-        self._decode_semaphore = asyncio.Semaphore(2)
+        self._decode_semaphore = asyncio.Semaphore(1)
         os.environ["VISION_LOG_FILE"] = log_path
 
     def _upstream_headers(self, incoming):
@@ -1168,6 +1188,7 @@ class Proxy:
     async def handle(self, reader, writer):
         response = None
         response_started = False
+        decode_slot_acquired = False
         try:
             request_head = await self._read_head(reader)
             if request_head is None:
@@ -1184,21 +1205,40 @@ class Proxy:
                     writer, 413,
                     f"Request body exceeds {MAX_REQUEST_BODY_BYTES} bytes")
                 return
+            content_encoding = _header_values(incoming_headers, "content-encoding")
+            try:
+                _content_codings(content_encoding)
+            except _InvalidContentEncoding as exc:
+                await self._send_error(writer, 400, str(exc))
+                return
+            if content_encoding:
+                await self._decode_semaphore.acquire()
+                decode_slot_acquired = True
             body = bytearray(body_start)
+            body_deadline = asyncio.get_running_loop().time() + REQUEST_BODY_READ_TIMEOUT
             while len(body) < content_length:
-                chunk = await reader.read(min(65536, content_length - len(body)))
+                remaining = body_deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    await self._send_error(writer, 408, "request body read timed out")
+                    return
+                try:
+                    chunk = await asyncio.wait_for(
+                        reader.read(min(65536, content_length - len(body))),
+                        timeout=remaining,
+                    )
+                except TimeoutError:
+                    await self._send_error(writer, 408, "request body read timed out")
+                    return
                 if not chunk:
                     break
                 body.extend(chunk)
             if len(body) < content_length:
                 await self._send_error(writer, 400, "incomplete request body")
                 return
-            content_encoding = _header_values(incoming_headers, "content-encoding")
             try:
                 if content_encoding:
-                    async with self._decode_semaphore:
-                        body = await asyncio.to_thread(
-                            _decode_request_body, bytes(body), content_encoding)
+                    body = await asyncio.to_thread(
+                        _decode_request_body, body, content_encoding)
                     if not isinstance(body, bytearray):
                         body = bytearray(body)
             except _RequestBodyTooLarge as exc:
@@ -1213,10 +1253,17 @@ class Proxy:
                 _log(f"[vision-proxy] request decode failed: {exc}")
                 await self._send_error(writer, 400, str(exc))
                 return
+            except _ContentDecoderError as exc:
+                _log(f"[vision-proxy] request decoder failed: {exc}")
+                await self._send_error(writer, 500, "Request decoder failed")
+                return
+            if decode_slot_acquired:
+                self._decode_semaphore.release()
+                decode_slot_acquired = False
             parsed = None
             if body:
                 try:
-                    parsed = json.loads(bytes(body))
+                    parsed = json.loads(body)
                 except (json.JSONDecodeError, UnicodeDecodeError):
                     pass
             if isinstance(parsed, dict):
@@ -1243,6 +1290,8 @@ class Proxy:
             if not response_started:
                 await self._send_error(writer, 502, "Upstream proxy request failed")
         finally:
+            if decode_slot_acquired:
+                self._decode_semaphore.release()
             if response is not None:
                 response.close()
             writer.close()

--- a/vision_proxy.py
+++ b/vision_proxy.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import ctypes
+import ctypes.util
+import gzip
 from http import HTTPStatus
 import http.client
 import hashlib
+import io
 import json
 import os
 import re
@@ -16,6 +20,7 @@ import socket
 import ssl
 import time
 import urllib.parse
+import zlib
 
 from vision_client import VisionError, describe_image, load_env_file, validate_vision_config
 
@@ -37,6 +42,180 @@ def _authority(host, port):
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"
     return f"{host}:{port}"
+
+
+class _UnsupportedContentEncoding(ValueError):
+    pass
+
+
+class _InvalidContentEncoding(ValueError):
+    pass
+
+
+class _ZstdInBuffer(ctypes.Structure):
+    _fields_ = [("src", ctypes.c_void_p),
+                ("size", ctypes.c_size_t),
+                ("pos", ctypes.c_size_t)]
+
+
+class _ZstdOutBuffer(ctypes.Structure):
+    _fields_ = [("dst", ctypes.c_void_p),
+                ("size", ctypes.c_size_t),
+                ("pos", ctypes.c_size_t)]
+
+
+_ZSTD_LIBRARY = None
+
+
+def _load_zstd_library():
+    global _ZSTD_LIBRARY
+    if _ZSTD_LIBRARY is not None:
+        return _ZSTD_LIBRARY
+
+    candidates = [ctypes.util.find_library("zstd"),
+                  "/opt/homebrew/lib/libzstd.dylib",
+                  "/usr/local/lib/libzstd.dylib",
+                  "/usr/lib/libzstd.so.1",
+                  "/usr/lib/x86_64-linux-gnu/libzstd.so.1",
+                  "/usr/lib/aarch64-linux-gnu/libzstd.so.1",
+                  "libzstd.so.1", "libzstd.so", "libzstd.dylib",
+                  "libzstd.dll", "zstd.dll"]
+    for root in (os.environ.get("ProgramFiles"), os.environ.get("ProgramFiles(x86)"),
+                 os.environ.get("LOCALAPPDATA")):
+        if root:
+            candidates.append(os.path.join(root, "Git", "mingw64", "bin", "libzstd.dll"))
+            candidates.append(os.path.join(root, "Programs", "Git", "mingw64", "bin",
+                                           "libzstd.dll"))
+    library = None
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            library = ctypes.CDLL(candidate)
+            break
+        except OSError:
+            continue
+    if library is None:
+        raise _UnsupportedContentEncoding(
+            "Unsupported Content-Encoding: zstd (libzstd is unavailable)")
+
+    library.ZSTD_createDStream.argtypes = []
+    library.ZSTD_createDStream.restype = ctypes.c_void_p
+    library.ZSTD_freeDStream.argtypes = [ctypes.c_void_p]
+    library.ZSTD_freeDStream.restype = ctypes.c_size_t
+    library.ZSTD_initDStream.argtypes = [ctypes.c_void_p]
+    library.ZSTD_initDStream.restype = ctypes.c_size_t
+    library.ZSTD_DStreamOutSize.argtypes = []
+    library.ZSTD_DStreamOutSize.restype = ctypes.c_size_t
+    library.ZSTD_decompressStream.argtypes = [ctypes.c_void_p,
+                                               ctypes.POINTER(_ZstdOutBuffer),
+                                               ctypes.POINTER(_ZstdInBuffer)]
+    library.ZSTD_decompressStream.restype = ctypes.c_size_t
+    library.ZSTD_isError.argtypes = [ctypes.c_size_t]
+    library.ZSTD_isError.restype = ctypes.c_uint
+    library.ZSTD_getErrorName.argtypes = [ctypes.c_size_t]
+    library.ZSTD_getErrorName.restype = ctypes.c_char_p
+    _ZSTD_LIBRARY = library
+    return library
+
+
+def _zstd_error(library, result):
+    if not library.ZSTD_isError(result):
+        return None
+    name = library.ZSTD_getErrorName(result)
+    return name.decode("utf-8", errors="replace") if name else "unknown zstd error"
+
+
+def _decompress_zstd_native(body):
+    library = _load_zstd_library()
+    stream = library.ZSTD_createDStream()
+    if not stream:
+        raise _InvalidContentEncoding("Invalid zstd request body: cannot create decoder")
+
+    source = ctypes.create_string_buffer(body)
+    input_buffer = _ZstdInBuffer(ctypes.cast(source, ctypes.c_void_p), len(body), 0)
+    chunks = []
+    try:
+        result = library.ZSTD_initDStream(stream)
+        error = _zstd_error(library, result)
+        if error:
+            raise _InvalidContentEncoding(f"Invalid zstd request body: {error}")
+
+        output_size = library.ZSTD_DStreamOutSize()
+        while input_buffer.pos < input_buffer.size or result != 0:
+            output = ctypes.create_string_buffer(output_size)
+            output_buffer = _ZstdOutBuffer(ctypes.cast(output, ctypes.c_void_p), output_size, 0)
+            previous_input_pos = input_buffer.pos
+            result = library.ZSTD_decompressStream(
+                stream, ctypes.byref(output_buffer), ctypes.byref(input_buffer))
+            error = _zstd_error(library, result)
+            if error:
+                raise _InvalidContentEncoding(f"Invalid zstd request body: {error}")
+            if output_buffer.pos:
+                chunks.append(output.raw[:output_buffer.pos])
+            if result == 0 and input_buffer.pos == input_buffer.size:
+                break
+            if input_buffer.pos == previous_input_pos and output_buffer.pos == 0:
+                raise _InvalidContentEncoding("Invalid zstd request body: truncated frame")
+    finally:
+        library.ZSTD_freeDStream(stream)
+    return b"".join(chunks)
+
+
+def _decompress_zstd(body):
+    try:
+        from compression import zstd
+    except ImportError:
+        pass
+    else:
+        try:
+            return zstd.decompress(body)
+        except Exception as exc:
+            raise _InvalidContentEncoding(f"Invalid zstd request body: {exc}") from exc
+
+    try:
+        return _decompress_zstd_native(body)
+    except _UnsupportedContentEncoding as native_error:
+        # Keep the proxy dependency-free, but use the widely available Python
+        # binding when a platform does not expose libzstd as a shared library.
+        try:
+            import zstandard
+        except ImportError:
+            raise native_error
+        try:
+            with zstandard.ZstdDecompressor().stream_reader(io.BytesIO(body)) as reader:
+                return reader.read()
+        except Exception as exc:
+            raise _InvalidContentEncoding(f"Invalid zstd request body: {exc}") from exc
+
+
+def _decode_request_body(body, content_encoding):
+    codings = [coding.strip().lower() for coding in (content_encoding or "").split(",")
+               if coding.strip()]
+    for coding in reversed(codings):
+        try:
+            if coding == "identity":
+                continue
+            if coding in ("gzip", "x-gzip"):
+                body = gzip.decompress(body)
+            elif coding == "deflate":
+                try:
+                    body = zlib.decompress(body)
+                except zlib.error:
+                    body = zlib.decompress(body, -zlib.MAX_WBITS)
+            elif coding == "zstd":
+                body = _decompress_zstd(body)
+            else:
+                raise _UnsupportedContentEncoding(
+                    f"Unsupported Content-Encoding: {coding}")
+        except _UnsupportedContentEncoding:
+            raise
+        except _InvalidContentEncoding:
+            raise
+        except (OSError, EOFError, zlib.error) as exc:
+            raise _InvalidContentEncoding(
+                f"Invalid {coding} request body: {exc}") from exc
+    return body
 
 
 _DESC_CACHE = {}
@@ -908,7 +1087,7 @@ class Proxy:
         headers = []
         for key, value in incoming:
             lower = key.lower()
-            if lower in HOP_HEADERS:
+            if lower in HOP_HEADERS or lower == "content-encoding":
                 continue
             if self.codex_header_compat and (lower in CODEX_HEADERS or lower.startswith("x-codex-")):
                 continue
@@ -941,11 +1120,22 @@ class Proxy:
             if len(body) < content_length:
                 await self._send_error(writer, 400, "incomplete request body")
                 return
+            try:
+                body = bytearray(_decode_request_body(
+                    bytes(body), _header_value(incoming_headers, "content-encoding")))
+            except _UnsupportedContentEncoding as exc:
+                _log(f"[vision-proxy] request decode rejected: {exc}")
+                await self._send_error(writer, 415, str(exc))
+                return
+            except _InvalidContentEncoding as exc:
+                _log(f"[vision-proxy] request decode failed: {exc}")
+                await self._send_error(writer, 400, str(exc))
+                return
             parsed = None
             if body:
                 try:
                     parsed = json.loads(bytes(body))
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, UnicodeDecodeError):
                     pass
             if isinstance(parsed, dict):
                 image_changed = await _rewrite_image_inputs(parsed)

--- a/vision_proxy.py
+++ b/vision_proxy.py
@@ -18,6 +18,7 @@ import re
 import signal
 import socket
 import ssl
+import threading
 import time
 import urllib.parse
 import zlib
@@ -32,10 +33,18 @@ CODEX_HEADERS = {"originator", "session-id", "thread-id", "user-agent"}
 # streaming keeps the long read timeout the proxy always had (600s).
 EGRESS_CONNECT_TIMEOUT = 5.0
 EGRESS_READ_TIMEOUT = 600.0
+MAX_REQUEST_BODY_BYTES = 64 * 1024 * 1024
+MAX_DECODED_BODY_BYTES = 64 * 1024 * 1024
+DECODE_CHUNK_BYTES = 64 * 1024
+ZSTD_WINDOW_LOG_MAX = 26
 
 
 def _header_value(headers, name):
     return next((value for key, value in headers if key.lower() == name.lower()), None)
+
+
+def _header_values(headers, name):
+    return ", ".join(value for key, value in headers if key.lower() == name.lower())
 
 
 def _authority(host, port):
@@ -52,6 +61,10 @@ class _InvalidContentEncoding(ValueError):
     pass
 
 
+class _RequestBodyTooLarge(ValueError):
+    pass
+
+
 class _ZstdInBuffer(ctypes.Structure):
     _fields_ = [("src", ctypes.c_void_p),
                 ("size", ctypes.c_size_t),
@@ -65,58 +78,65 @@ class _ZstdOutBuffer(ctypes.Structure):
 
 
 _ZSTD_LIBRARY = None
+_ZSTD_LIBRARY_LOCK = threading.Lock()
 
 
 def _load_zstd_library():
     global _ZSTD_LIBRARY
     if _ZSTD_LIBRARY is not None:
         return _ZSTD_LIBRARY
+    with _ZSTD_LIBRARY_LOCK:
+        if _ZSTD_LIBRARY is not None:
+            return _ZSTD_LIBRARY
 
-    candidates = [ctypes.util.find_library("zstd"),
-                  "/opt/homebrew/lib/libzstd.dylib",
-                  "/usr/local/lib/libzstd.dylib",
-                  "/usr/lib/libzstd.so.1",
-                  "/usr/lib/x86_64-linux-gnu/libzstd.so.1",
-                  "/usr/lib/aarch64-linux-gnu/libzstd.so.1",
-                  "libzstd.so.1", "libzstd.so", "libzstd.dylib",
-                  "libzstd.dll", "zstd.dll"]
-    for root in (os.environ.get("ProgramFiles"), os.environ.get("ProgramFiles(x86)"),
-                 os.environ.get("LOCALAPPDATA")):
-        if root:
-            candidates.append(os.path.join(root, "Git", "mingw64", "bin", "libzstd.dll"))
-            candidates.append(os.path.join(root, "Programs", "Git", "mingw64", "bin",
-                                           "libzstd.dll"))
-    library = None
-    for candidate in candidates:
-        if not candidate:
-            continue
-        try:
-            library = ctypes.CDLL(candidate)
-            break
-        except OSError:
-            continue
-    if library is None:
-        raise _UnsupportedContentEncoding(
-            "Unsupported Content-Encoding: zstd (libzstd is unavailable)")
+        candidates = [ctypes.util.find_library("zstd"),
+                      "/opt/homebrew/lib/libzstd.dylib",
+                      "/usr/local/lib/libzstd.dylib",
+                      "/usr/lib/libzstd.so.1",
+                      "/usr/lib/x86_64-linux-gnu/libzstd.so.1",
+                      "/usr/lib/aarch64-linux-gnu/libzstd.so.1",
+                      "libzstd.so.1", "libzstd.so", "libzstd.dylib",
+                      "libzstd.dll", "zstd.dll"]
+        for root in (os.environ.get("ProgramFiles"), os.environ.get("ProgramFiles(x86)"),
+                     os.environ.get("LOCALAPPDATA")):
+            if root:
+                candidates.append(os.path.join(root, "Git", "mingw64", "bin", "libzstd.dll"))
+                candidates.append(os.path.join(root, "Programs", "Git", "mingw64", "bin",
+                                               "libzstd.dll"))
+        library = None
+        for candidate in dict.fromkeys(candidates):
+            if not candidate:
+                continue
+            try:
+                library = ctypes.CDLL(candidate)
+                break
+            except OSError:
+                continue
+        if library is None:
+            raise _UnsupportedContentEncoding(
+                "Unsupported Content-Encoding: zstd (no decoder is available)")
 
-    library.ZSTD_createDStream.argtypes = []
-    library.ZSTD_createDStream.restype = ctypes.c_void_p
-    library.ZSTD_freeDStream.argtypes = [ctypes.c_void_p]
-    library.ZSTD_freeDStream.restype = ctypes.c_size_t
-    library.ZSTD_initDStream.argtypes = [ctypes.c_void_p]
-    library.ZSTD_initDStream.restype = ctypes.c_size_t
-    library.ZSTD_DStreamOutSize.argtypes = []
-    library.ZSTD_DStreamOutSize.restype = ctypes.c_size_t
-    library.ZSTD_decompressStream.argtypes = [ctypes.c_void_p,
-                                               ctypes.POINTER(_ZstdOutBuffer),
-                                               ctypes.POINTER(_ZstdInBuffer)]
-    library.ZSTD_decompressStream.restype = ctypes.c_size_t
-    library.ZSTD_isError.argtypes = [ctypes.c_size_t]
-    library.ZSTD_isError.restype = ctypes.c_uint
-    library.ZSTD_getErrorName.argtypes = [ctypes.c_size_t]
-    library.ZSTD_getErrorName.restype = ctypes.c_char_p
-    _ZSTD_LIBRARY = library
-    return library
+        library.ZSTD_createDStream.argtypes = []
+        library.ZSTD_createDStream.restype = ctypes.c_void_p
+        library.ZSTD_freeDStream.argtypes = [ctypes.c_void_p]
+        library.ZSTD_freeDStream.restype = ctypes.c_size_t
+        library.ZSTD_initDStream.argtypes = [ctypes.c_void_p]
+        library.ZSTD_initDStream.restype = ctypes.c_size_t
+        library.ZSTD_DStreamOutSize.argtypes = []
+        library.ZSTD_DStreamOutSize.restype = ctypes.c_size_t
+        library.ZSTD_decompressStream.argtypes = [ctypes.c_void_p,
+                                                   ctypes.POINTER(_ZstdOutBuffer),
+                                                   ctypes.POINTER(_ZstdInBuffer)]
+        library.ZSTD_decompressStream.restype = ctypes.c_size_t
+        library.ZSTD_DCtx_setParameter.argtypes = [ctypes.c_void_p, ctypes.c_int,
+                                                    ctypes.c_int]
+        library.ZSTD_DCtx_setParameter.restype = ctypes.c_size_t
+        library.ZSTD_isError.argtypes = [ctypes.c_size_t]
+        library.ZSTD_isError.restype = ctypes.c_uint
+        library.ZSTD_getErrorName.argtypes = [ctypes.c_size_t]
+        library.ZSTD_getErrorName.restype = ctypes.c_char_p
+        _ZSTD_LIBRARY = library
+        return library
 
 
 def _zstd_error(library, result):
@@ -124,6 +144,23 @@ def _zstd_error(library, result):
         return None
     name = library.ZSTD_getErrorName(result)
     return name.decode("utf-8", errors="replace") if name else "unknown zstd error"
+
+
+def _append_decoded(output, chunk):
+    if len(output) + len(chunk) > MAX_DECODED_BODY_BYTES:
+        raise _RequestBodyTooLarge(
+            f"Decoded request body exceeds {MAX_DECODED_BODY_BYTES} bytes")
+    output.extend(chunk)
+
+
+def _read_decoded_stream(reader):
+    output = bytearray()
+    while True:
+        chunk = reader.read(min(DECODE_CHUNK_BYTES,
+                                MAX_DECODED_BODY_BYTES - len(output) + 1))
+        if not chunk:
+            return output
+        _append_decoded(output, chunk)
 
 
 def _decompress_zstd_native(body):
@@ -134,8 +171,12 @@ def _decompress_zstd_native(body):
 
     source = ctypes.create_string_buffer(body)
     input_buffer = _ZstdInBuffer(ctypes.cast(source, ctypes.c_void_p), len(body), 0)
-    chunks = []
+    output_bytes = bytearray()
     try:
+        result = library.ZSTD_DCtx_setParameter(stream, 100, ZSTD_WINDOW_LOG_MAX)
+        error = _zstd_error(library, result)
+        if error:
+            raise _InvalidContentEncoding(f"Invalid zstd request body: {error}")
         result = library.ZSTD_initDStream(stream)
         error = _zstd_error(library, result)
         if error:
@@ -152,14 +193,14 @@ def _decompress_zstd_native(body):
             if error:
                 raise _InvalidContentEncoding(f"Invalid zstd request body: {error}")
             if output_buffer.pos:
-                chunks.append(output.raw[:output_buffer.pos])
+                _append_decoded(output_bytes, output.raw[:output_buffer.pos])
             if result == 0 and input_buffer.pos == input_buffer.size:
                 break
             if input_buffer.pos == previous_input_pos and output_buffer.pos == 0:
                 raise _InvalidContentEncoding("Invalid zstd request body: truncated frame")
     finally:
         library.ZSTD_freeDStream(stream)
-    return b"".join(chunks)
+    return output_bytes
 
 
 def _decompress_zstd(body):
@@ -169,8 +210,10 @@ def _decompress_zstd(body):
         pass
     else:
         try:
-            return zstd.decompress(body)
-        except Exception as exc:
+            options = {zstd.DecompressionParameter.window_log_max: ZSTD_WINDOW_LOG_MAX}
+            with zstd.open(io.BytesIO(body), "rb", options=options) as reader:
+                return _read_decoded_stream(reader)
+        except zstd.ZstdError as exc:
             raise _InvalidContentEncoding(f"Invalid zstd request body: {exc}") from exc
 
     try:
@@ -183,10 +226,33 @@ def _decompress_zstd(body):
         except ImportError:
             raise native_error
         try:
-            with zstandard.ZstdDecompressor().stream_reader(io.BytesIO(body)) as reader:
-                return reader.read()
-        except Exception as exc:
+            decompressor = zstandard.ZstdDecompressor(
+                max_window_size=1 << ZSTD_WINDOW_LOG_MAX)
+            with decompressor.stream_reader(io.BytesIO(body)) as reader:
+                return _read_decoded_stream(reader)
+        except zstandard.ZstdError as exc:
             raise _InvalidContentEncoding(f"Invalid zstd request body: {exc}") from exc
+
+
+def _decompress_deflate(body, wbits):
+    decoder = zlib.decompressobj(wbits)
+    output = bytearray()
+    pending = body
+    while pending:
+        before = len(pending)
+        chunk = decoder.decompress(
+            pending, min(DECODE_CHUNK_BYTES, MAX_DECODED_BODY_BYTES - len(output) + 1))
+        _append_decoded(output, chunk)
+        pending = decoder.unconsumed_tail
+        if pending and len(pending) == before and not chunk:
+            raise _InvalidContentEncoding("Invalid deflate request body: decoder made no progress")
+    if not decoder.eof:
+        raise _InvalidContentEncoding("Invalid deflate request body: truncated stream")
+    _append_decoded(
+        output,
+        decoder.flush(min(DECODE_CHUNK_BYTES, MAX_DECODED_BODY_BYTES - len(output) + 1)),
+    )
+    return output
 
 
 def _decode_request_body(body, content_encoding):
@@ -197,12 +263,13 @@ def _decode_request_body(body, content_encoding):
             if coding == "identity":
                 continue
             if coding in ("gzip", "x-gzip"):
-                body = gzip.decompress(body)
+                with gzip.GzipFile(fileobj=io.BytesIO(body)) as reader:
+                    body = _read_decoded_stream(reader)
             elif coding == "deflate":
                 try:
-                    body = zlib.decompress(body)
+                    body = _decompress_deflate(body, zlib.MAX_WBITS)
                 except zlib.error:
-                    body = zlib.decompress(body, -zlib.MAX_WBITS)
+                    body = _decompress_deflate(body, -zlib.MAX_WBITS)
             elif coding == "zstd":
                 body = _decompress_zstd(body)
             else:
@@ -1081,6 +1148,7 @@ class Proxy:
             self._routes.append(_EgressRoute("proxy", upstream_proxy))
         if proxy_first and len(self._routes) > 1:
             self._routes.reverse()
+        self._decode_semaphore = asyncio.Semaphore(2)
         os.environ["VISION_LOG_FILE"] = log_path
 
     def _upstream_headers(self, incoming):
@@ -1111,6 +1179,11 @@ class Proxy:
             except ValueError:
                 await self._send_error(writer, 400, "invalid Content-Length")
                 return
+            if content_length > MAX_REQUEST_BODY_BYTES:
+                await self._send_error(
+                    writer, 413,
+                    f"Request body exceeds {MAX_REQUEST_BODY_BYTES} bytes")
+                return
             body = bytearray(body_start)
             while len(body) < content_length:
                 chunk = await reader.read(min(65536, content_length - len(body)))
@@ -1120,9 +1193,18 @@ class Proxy:
             if len(body) < content_length:
                 await self._send_error(writer, 400, "incomplete request body")
                 return
+            content_encoding = _header_values(incoming_headers, "content-encoding")
             try:
-                body = bytearray(_decode_request_body(
-                    bytes(body), _header_value(incoming_headers, "content-encoding")))
+                if content_encoding:
+                    async with self._decode_semaphore:
+                        body = await asyncio.to_thread(
+                            _decode_request_body, bytes(body), content_encoding)
+                    if not isinstance(body, bytearray):
+                        body = bytearray(body)
+            except _RequestBodyTooLarge as exc:
+                _log(f"[vision-proxy] request decode rejected: {exc}")
+                await self._send_error(writer, 413, str(exc))
+                return
             except _UnsupportedContentEncoding as exc:
                 _log(f"[vision-proxy] request decode rejected: {exc}")
                 await self._send_error(writer, 415, str(exc))

--- a/vision_proxy.py
+++ b/vision_proxy.py
@@ -174,7 +174,9 @@ def _raise_python_zstd_error(exc):
     message = str(exc)
     internal_markers = (
         "allocation", "not enough memory", "workspace", "internal error",
-        "stage wrong", "init missing",
+        "current processing stage", "context should be init first",
+        "destination buffer is too small", "null destination buffer",
+        "output buffer being full", "input being empty",
     )
     if any(marker in message.lower() for marker in internal_markers):
         raise _ContentDecoderError(f"zstd decoder failed: {message}") from exc
@@ -254,24 +256,7 @@ def _decompress_zstd(body):
         except zstd.ZstdError as exc:
             _raise_python_zstd_error(exc)
 
-    try:
-        return _decompress_zstd_native(body)
-    except _UnsupportedContentEncoding as native_error:
-        # Keep the proxy dependency-free, but use the widely available Python
-        # binding when a platform does not expose libzstd as a shared library.
-        try:
-            import zstandard
-        except ImportError:
-            raise native_error
-        try:
-            decompressor = zstandard.ZstdDecompressor(
-                max_window_size=1 << ZSTD_WINDOW_LOG_MAX)
-            with decompressor.stream_reader(io.BytesIO(body)) as reader:
-                return _read_decoded_stream(reader)
-        except MemoryError as exc:
-            raise _ContentDecoderError("zstd decoder ran out of memory") from exc
-        except zstandard.ZstdError as exc:
-            _raise_python_zstd_error(exc)
+    return _decompress_zstd_native(body)
 
 
 def _decompress_deflate(body, wbits):


### PR DESCRIPTION
## Summary

Fixes #29.

Codex Desktop compresses larger request bodies with `Content-Encoding: zstd`. The proxy previously passed those bytes directly to `json.loads`, so image requests raised `UnicodeDecodeError` and surfaced as a misleading 502.

This change decodes request bodies before JSON inspection, rewrites image inputs as usual, and forwards plaintext upstream with `Content-Encoding` removed.

## Changes

- Decodes `zstd`, `gzip` / `x-gzip`, and `deflate` (zlib-wrapped with raw-deflate fallback) request bodies; repeated `Content-Encoding` headers are merged in wire order and decoded in reverse order.
- zstd decoder chain:
  - Python 3.14+ standard library `compression.zstd`, when available;
  - system `libzstd` through a ctypes streaming decoder (macOS / Linux / Windows candidates, each candidate symbol-checked before use);
  - an installed `zstandard` package fallback using incremental `decompressobj()` decoding with per-frame completion checks.
- Strips `Content-Encoding` before forwarding the decoded body upstream.
- Explicit error statuses instead of a misleading 502:
  - `415` for unsupported encodings (decided before the body is read);
  - `400` for corrupt, incomplete, or truncated compressed bodies, and for more than 4 encoding layers;
  - `413` when the wire body or the decoded body exceeds 64 MiB;
  - `408` when the body cannot be read (or the single decode slot cannot be acquired) within 30 s;
  - `500` for decoder-internal failures (allocation, workspace, initialization), never attributed to the client.
- Bounded resource usage: 64 MiB wire-body cap, 64 MiB decoded-body cap, zstd window-log limit (2^26), and a single-concurrency decode slot. The slot is held only while the compressed body is read and decoded, then released before image rewriting and upstream egress, so concurrent compressed requests are not serialized through slow vision calls or upstream responses.
- The 30 s read/decode-queue deadline applies only to compressed bodies; identity-only requests keep the proxy's original unbounded body-read behavior. A request that waits too long for the decode slot gets a distinct 408 message instead of a misleading "body read timed out".
- Malformed or non-JSON byte bodies still pass through unchanged; `UnicodeDecodeError` can no longer escape.

## Tests

- New `tests/test_request_content_encoding.py` covers zstd frames (with and without embedded content size), gzip, zlib and raw deflate, layered encodings, unsupported / over-layered encodings, truncated deflate streams, decoded-size limits, native decoder error classification, and — when `zstandard` is installed — truncated-frame, trailing-junk, and concatenated-frame rejection in the fallback.
- `tests/smoke_test_proxy.py` adds an end-to-end regression: a zstd-compressed `function_call_output.output` image request is decoded, rewritten, forwarded without `Content-Encoding`, and returns 200; unsupported `br` returns 415 before the body is read; invalid zstd returns 400.
- `tests/test_request_content_encoding.py` also runs two live-proxy concurrency regressions: two simultaneous zstd requests both return 200 even when the upstream is slower than the decode deadline, and an identity request whose body arrives after the compressed-read deadline is still accepted.
- CI runs the encoding tests in the Linux and Windows jobs; the Windows job now covers Python 3.11 and 3.14, and the Python 3.11 CI job installs `zstandard==0.25.0` so the fallback path is exercised.

## Verification

Passed locally:

- `python3 -m py_compile vision_proxy.py vision_client.py ground.py detect.py bin/glance bin/trace bin/crop skills/vision-tools/scripts/html_shot.py`
- `python3 tests/test_image_rewrite_shapes.py`
- `python3 tests/test_focus_hint.py`
- `python3 tests/test_anthropic_rewrite.py`
- `python3 tests/test_request_content_encoding.py`
- `python3 tests/smoke_test_proxy.py`
- `python3 tests/smoke_test_egress_failover.py`
- `python3 tests/test_vision_client.py`
- `python3 tests/test_html_shot.py`
- `python3 tests/test_restore_ui_playbook.py`
- `python3 tests/test_trace.py`
- `python3.11 tests/test_request_content_encoding.py`
- `python3.14 tests/test_request_content_encoding.py`
- `python3.14 tests/smoke_test_proxy.py`
- `git diff --check`

The optional `vtracer` / Pillow CLI execution remained skipped because those optional dependencies are not installed; the trace unit checks passed.

CI is green on all five jobs (`python-core` 3.11/3.14, `python-egress-windows` 3.11/3.14, `extensions`).

## User-path verification

This is a non-UI proxy protocol change. The real affected path was exercised end-to-end with a local HTTP client sending a zstd frame shaped like Codex Desktop's `view_image` Responses payload. The proxy returned 200, rewrote the `input_image`, forwarded decoded JSON, and removed `Content-Encoding`. Invalid zstd returned 400 and unsupported `br` returned 415.
