### PR TITLE
fix: add `stream: false` to chat_completions payload

### DIFF
--- a/vision_client.py
+++ b/vision_client.py
@@ -221,6 +221,7 @@ def describe_image(image_url: str | list[str], prompt: str | None = None, max_to
     elif protocol == "chat_completions":
         payload = {
             "model": model,
+            "stream": False,
             "messages": [{"role": "user", "content": [
             {"type": "image_url", "image_url": {"url": url}} for url in urls
             ] + [{"type": "text", "text": text}]}],


### PR DESCRIPTION
## Summary

Adds `"stream": False` to the `chat_completions` protocol payload in `vision_client.py`.

## Problem

Some OpenAI-compatible endpoints return SSE streaming format (`data: {...}`) by default, even for non-streaming requests. Without `stream: false` in the payload, `json.load(response)` fails to parse the `data:`-prefixed SSE body, and the error is reported as:

```
Vision API returned invalid JSON
```

## Fix

One-line addition — set `"stream": False` explicitly:

```python
payload = {
    "model": model,
    "stream": False,          # ← added
    "messages": [...],
}
```

This does not affect endpoints that already default to non-streaming responses.

## Testing

Tested against an internal OpenAI-compatible gateway that defaults to streaming SSE. Before the fix: `Vision API returned invalid JSON`. After the fix: response parsed correctly and vision operations succeeded.

Closes #33