### PR TITLE
feat: add `VISION_FORCE_NON_STREAM` option for streaming-default endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,7 @@ LANG=zh
 # Optional outbound User-Agent override. The default is browser-compatible to avoid
 # gateways that block Python-urllib clients.
 # VISION_USER_AGENT=custom-vision-client/1.0
+# Set to 1/true/on/yes to send stream:false explicitly in chat_completions requests.
+# Some OpenAI-compatible endpoints default to SSE streaming, causing "invalid JSON".
+# Leave unset for standard endpoints that already return non-streaming JSON.
+# VISION_FORCE_NON_STREAM=1

--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ The standalone CLIs and Python proxy use these environment variables; just three
 | `VISION_REASONING_EFFORT` | No | Optional provider-supported reasoning effort for the Python client/proxy when using `responses` |
 | `VISION_ANTHROPIC_THINKING` | No | Anthropic thinking mode. `omit` (default) sends no thinking field and has the broadest compatibility. Use `disabled` or `adaptive` only when the selected model documents that mode; restore `omit` first if the provider returns HTTP 400. Manual `enabled` plus `budget_tokens` is not exposed. |
 | `VISION_USER_AGENT` | No | Outbound User-Agent for the Python client/proxy; defaults to a browser-compatible value and can be overridden for provider requirements |
+| `VISION_FORCE_NON_STREAM` | No | Set to `1`/`true`/`on`/`yes` to send `stream: false` explicitly in `chat_completions` requests. Some OpenAI-compatible endpoints default to SSE streaming, causing `Vision API returned invalid JSON`. Leave unset for standard endpoints that already return non-streaming JSON |
 
 </details>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -351,6 +351,7 @@ Codex -> 127.0.0.1:19100 -> 用户原有的纯文本模型上游
 | `VISION_REASONING_EFFORT` | 否 | Python 客户端/代理使用 `responses` 时可选的服务商支持推理强度 |
 | `VISION_ANTHROPIC_THINKING` | 否 | Anthropic thinking 模式。`omit`（默认）不发送 thinking 字段，兼容性最好；仅当所选模型明确支持时使用 `disabled` 或 `adaptive`，提供方返回 HTTP 400 时应先恢复 `omit`。当前不提供手动 `enabled` + `budget_tokens`。 |
 | `VISION_USER_AGENT` | 否 | Python 客户端/代理的出站 User-Agent；默认使用浏览器兼容值，也可按服务商要求覆盖 |
+| `VISION_FORCE_NON_STREAM` | 否 | 设为 `1`/`true`/`on`/`yes` 时在 `chat_completions` 请求中显式发送 `stream: false`。部分 OpenAI 兼容端点默认返回 SSE 流式格式，导致 `Vision API returned invalid JSON`；标准端点无需设置 |
 
 </details>
 

--- a/vision_client.py
+++ b/vision_client.py
@@ -227,6 +227,11 @@ def describe_image(image_url: str | list[str], prompt: str | None = None, max_to
         }
         if max_tokens is not None:
             payload["max_tokens"] = max_tokens
+        # Some OpenAI-compatible endpoints default to SSE streaming even for
+        # non-streaming requests, returning a data:-prefixed body that
+        # json.load cannot parse. Setting stream:false explicitly avoids that.
+        if os.environ.get("VISION_FORCE_NON_STREAM", "").strip().lower() in ("1", "true", "on", "yes"):
+            payload["stream"] = False
         endpoint = "/chat/completions"
         extract_text = lambda data: _message_text(data["choices"][0]["message"]["content"])
     elif protocol == "anthropic":


### PR DESCRIPTION
## Summary

Adds a new `VISION_FORCE_NON_STREAM` environment variable that, when set to `1`/`true`/`on`/`yes`, explicitly sends `"stream": false` in `chat_completions` requests.

## Problem

Some OpenAI-compatible endpoints return SSE streaming format (`data: {...}`) by default, even for non-streaming requests. Without `stream: false` in the payload, `json.load(response)` fails to parse the `data:`-prefixed SSE body, and the error is reported as:

```
Vision API returned invalid JSON
```

Not all endpoints have this behavior — most standard OpenAI-compatible APIs already return non-streaming JSON by default. So a hard-coded `stream: false` would be an unnecessary change to the wire format for the majority of users.

## Solution

Make it opt-in via an environment variable:

```python
if os.environ.get("VISION_FORCE_NON_STREAM", "").strip().lower() in ("1", "true", "on", "yes"):
    payload["stream"] = False
```

- **Unset (default)**: no change to current behavior — standard endpoints keep working as before
- **Set to `1`/`true`/`on`/`yes`**: sends `stream: false` explicitly for endpoints that default to streaming SSE

## Changes

- `vision_client.py`: conditional `stream: false` in the `chat_completions` branch
- `.env.example`: documented the new variable
- `README.md` / `README_CN.md`: added to the environment variables table

## Testing

Tested against an internal OpenAI-compatible gateway that defaults to streaming SSE. With `VISION_FORCE_NON_STREAM=1`: response parsed correctly and vision operations succeeded. Without the variable: standard endpoints continued to work unchanged.

Closes #33