### PR TITLE
fix: decompress gzip responses from OpenAI-compatible endpoints

### DIFF
--- a/tests/test_vision_client.py
+++ b/tests/test_vision_client.py
@@ -318,6 +318,47 @@ def main():
         finally:
             vision_client.time.sleep = original_sleep
 
+        invalid_gzip = b"\x1f\x8btruncated"
+        Handler.calls, Handler.statuses, Handler.bodies, Handler.response_headers = (
+            0,
+            [200, 200, 200],
+            [invalid_gzip] * 3,
+            [{"Content-Encoding": "gzip"}] * 3,
+        )
+        delays = []
+        original_sleep = vision_client.time.sleep
+        vision_client.time.sleep = delays.append
+        try:
+            vision_client.describe_image("data:image/png;base64,AAAA")
+        except vision_client.VisionError as exc:
+            assert "Invalid gzip response body" in str(exc)
+        else:
+            raise AssertionError("a corrupt gzip success response must raise VisionError")
+        finally:
+            vision_client.time.sleep = original_sleep
+        assert Handler.calls == 3, "a corrupt gzip success response must use bounded retries"
+        assert delays == [1, 2]
+
+        Handler.calls, Handler.statuses, Handler.bodies, Handler.response_headers = (
+            0,
+            [500, 500, 500],
+            [invalid_gzip] * 3,
+            [{"Content-Encoding": "gzip"}] * 3,
+        )
+        delays = []
+        original_sleep = vision_client.time.sleep
+        vision_client.time.sleep = delays.append
+        try:
+            vision_client.describe_image("data:image/png;base64,AAAA")
+        except vision_client.VisionError as exc:
+            assert "Vision API HTTP 500: Invalid gzip response body" in str(exc)
+        else:
+            raise AssertionError("a corrupt gzip HTTP error body must raise VisionError")
+        finally:
+            vision_client.time.sleep = original_sleep
+        assert Handler.calls == 3, "a corrupt gzip HTTP error body must use bounded retries"
+        assert delays == [1, 2]
+
         Handler.calls, Handler.statuses, Handler.bodies, Handler.response_headers = 0, [200], [], []
         os.environ["VISION_API_PROTOCOL"] = "chat_completions"
         try:

--- a/tests/test_vision_client.py
+++ b/tests/test_vision_client.py
@@ -2,6 +2,7 @@
 """Core retry/error test for the shared vision client and glance CLI."""
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
+import gzip
 import json
 import os
 from pathlib import Path
@@ -288,6 +289,44 @@ def main():
         assert Handler.last_headers.get("User-Agent") == vision_client.DEFAULT_USER_AGENT
         image_parts = [part for part in content if part.get("type") == "image_url"]
         assert len(image_parts) == 2, "a list of URLs must become one request with all images"
+        assert Handler.calls == 1
+
+        gzip_body = gzip.compress(json.dumps({
+            "choices": [{"message": {"content": "gzip fixture answer"}}],
+        }).encode())
+        Handler.calls, Handler.statuses, Handler.bodies, Handler.response_headers = (
+            0, [200], [gzip_body], [{"Content-Encoding": "gzip"}]
+        )
+        assert vision_client.describe_image("data:image/png;base64,AAAA") == "gzip fixture answer"
+        assert Handler.calls == 1, "a gzip response must be decompressed on the first try"
+
+        Handler.calls, Handler.statuses, Handler.bodies, Handler.response_headers = (
+            0,
+            [500, 500, 500],
+            [gzip.compress(b'{"error":{"message":"gzip error body"}}')] * 3,
+            [{"Content-Encoding": "gzip"}] * 3,
+        )
+        delays = []
+        original_sleep = vision_client.time.sleep
+        vision_client.time.sleep = delays.append
+        try:
+            vision_client.describe_image("data:image/png;base64,AAAA")
+        except vision_client.VisionError as exc:
+            assert "gzip error body" in str(exc)
+        else:
+            raise AssertionError("a gzip HTTP error body must still surface the decoded message")
+        finally:
+            vision_client.time.sleep = original_sleep
+
+        Handler.calls, Handler.statuses, Handler.bodies, Handler.response_headers = 0, [200], [], []
+        os.environ["VISION_API_PROTOCOL"] = "chat_completions"
+        try:
+            vision_client.describe_image("data:image/png;base64,AAAA")
+        finally:
+            os.environ.pop("VISION_API_PROTOCOL", None)
+        payload = json.loads(Handler.last_body)
+        assert payload.get("stream") is False, \
+            "chat_completions must request a non-streaming response"
         assert Handler.calls == 1
 
         Handler.calls, Handler.statuses, Handler.bodies, Handler.response_headers = 0, [200], [json.dumps({

--- a/vision_client.py
+++ b/vision_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import base64
 from email.utils import parsedate_to_datetime
+import gzip
 import http.client
 import json
 import mimetypes
@@ -174,6 +175,18 @@ def _api_error_code(body: bytes) -> str:
     return code if isinstance(code, str) else ""
 
 
+def _decompress_body(raw: bytes, response) -> bytes:
+    """Decompress a response body when the server advertises gzip encoding.
+
+    urllib does not transparently decompress gzip responses; the bundled
+    http.client leaves the raw compressed bytes untouched.
+    """
+    encoding = (response.headers.get("Content-Encoding") or "").lower()
+    if encoding == "gzip" and raw[:2] == b"\x1f\x8b":
+        return gzip.decompress(raw)
+    return raw
+
+
 def _retryable_http_error(status: int, body: bytes) -> bool:
     if status not in {429, 500, 502, 503, 504, 529}:
         return False
@@ -268,7 +281,8 @@ def describe_image(image_url: str | list[str], prompt: str | None = None, max_to
     for attempt in range(retries + 1):
         try:
             with urllib.request.urlopen(request, timeout=timeout) as response:
-                data = json.load(response)
+                raw = response.read()
+                data = json.loads(_decompress_body(raw, response))
             try:
                 text = extract_text(data)
             except (KeyError, IndexError, TypeError) as exc:
@@ -277,7 +291,7 @@ def describe_image(image_url: str | list[str], prompt: str | None = None, max_to
                 raise VisionError("Vision API returned an empty description")
             return text
         except urllib.error.HTTPError as exc:
-            raw_body = exc.read()
+            raw_body = _decompress_body(exc.read(), exc)
             body = _redact(raw_body.decode(errors="replace")[:400], api_key)
             body = body.replace("\r", " ").replace("\n", " ")
             if _retryable_http_error(exc.code, raw_body) and attempt < retries:

--- a/vision_client.py
+++ b/vision_client.py
@@ -15,6 +15,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
+import zlib
 
 DEFAULT_PROMPT = "Please describe the contents of this image in detail."
 DEFAULT_USER_AGENT = (
@@ -31,6 +32,10 @@ LANG_INSTRUCTIONS = {
 
 class VisionError(RuntimeError):
     """A safe, user-facing vision request failure."""
+
+
+class _ResponseDecodeError(RuntimeError):
+    """An upstream response body could not be decoded safely."""
 
 
 def load_env_file(path: str | os.PathLike[str] | None) -> None:
@@ -181,9 +186,12 @@ def _decompress_body(raw: bytes, response) -> bytes:
     urllib does not transparently decompress gzip responses; the bundled
     http.client leaves the raw compressed bytes untouched.
     """
-    encoding = (response.headers.get("Content-Encoding") or "").lower()
+    encoding = (response.headers.get("Content-Encoding") or "").strip().lower()
     if encoding == "gzip" and raw[:2] == b"\x1f\x8b":
-        return gzip.decompress(raw)
+        try:
+            return gzip.decompress(raw)
+        except (OSError, EOFError, zlib.error) as exc:
+            raise _ResponseDecodeError("Invalid gzip response body") from exc
     return raw
 
 
@@ -291,7 +299,14 @@ def describe_image(image_url: str | list[str], prompt: str | None = None, max_to
                 raise VisionError("Vision API returned an empty description")
             return text
         except urllib.error.HTTPError as exc:
-            raw_body = _decompress_body(exc.read(), exc)
+            try:
+                raw_body = _decompress_body(exc.read(), exc)
+            except _ResponseDecodeError as decode_exc:
+                if _retryable_http_error(exc.code, b"") and attempt < retries:
+                    print(f"vision: HTTP {exc.code}, retrying ({attempt + 1}/{retries})", file=sys.stderr)
+                    time.sleep(_retry_delay(exc, attempt))
+                    continue
+                raise VisionError(f"Vision API HTTP {exc.code}: {decode_exc}") from decode_exc
             body = _redact(raw_body.decode(errors="replace")[:400], api_key)
             body = body.replace("\r", " ").replace("\n", " ")
             if _retryable_http_error(exc.code, raw_body) and attempt < retries:
@@ -306,6 +321,12 @@ def describe_image(image_url: str | list[str], prompt: str | None = None, max_to
                 continue
             reason = _redact(str(getattr(exc, "reason", str(exc))), api_key)
             raise VisionError(f"Vision API network error: {reason}") from exc
+        except _ResponseDecodeError as exc:
+            if attempt < retries:
+                print(f"vision: response decode error, retrying ({attempt + 1}/{retries})", file=sys.stderr)
+                time.sleep(min(2 ** attempt, 4))
+                continue
+            raise VisionError(f"Vision API response decode error: {exc}") from exc
         except json.JSONDecodeError as exc:
             raise VisionError("Vision API returned invalid JSON") from exc
     raise VisionError("Vision API request failed")


### PR DESCRIPTION
Some OpenAI-compatible gateways (e.g. internal proxies) always gzip-compress responses regardless of Accept-Encoding. urllib leaves the gzip bytes untouched, so json.load() fails with:
    UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1

Decompress the body whenever the server advertises Content-Encoding: gzip, on both the success and the HTTP-error paths, so decoded error messages still surface. Add coverage for gzip success/error bodies and for the chat_completions stream:false request flag.

## Summary

Describe the problem and the smallest change that solves it.

## Verification

List the exact commands you ran and their results.

## Checklist

- [ ] The change stays within the scope and invariants in `CONTRIBUTING.md`.
- [ ] I reused existing project tools and patterns instead of adding a parallel implementation.
- [ ] I added or updated focused tests for changed behavior.
- [ ] The required test suite and `git diff --check` pass.
- [ ] User-facing documentation is updated in both `README.md` and `README_CN.md` where applicable.
- [ ] Text-only requests, model names, and authentication headers remain unchanged unless the change explicitly targets that contract.
- [ ] No request bodies, images, prompts, conversations, API keys, or private machine paths are logged or committed.
- [ ] I did not modify `assets/` effect images unless the change explicitly requires it.
